### PR TITLE
'git pull' does NOT supports passing the directory into which you want t...

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -547,7 +547,8 @@ if [ ! "$(ls -A $OPENCOG_SOURCE_DIR)" ]; then
 else
   if [ $UPDATE_OPENCOG ] ; then
     MESSAGE="Updating OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
-    git pull git://github.com/opencog/opencog $OPENCOG_SOURCE_DIR
+    cd $OPENCOG_SOURCE_DIR
+    git pull git://github.com/opencog/opencog
   fi
 fi
 }


### PR DESCRIPTION
'git pull' does not supports passing the directory as command line argument. Quoting 'git help pull':

<pre>git pull [options] [<repository> [<refspec>...]]</pre>

As you can see in quoted text, there is no support for local directory/repo argument. Without this, git tries to pull into pwd (from where 'ocpkg' was run by user) instead of $OPENCOG_SOURCE_DIR.
This bug didn't popped up earlier maybe because no one tried to run 'ocpkg -v' second time. The very first time, 'git clone' is used. But if user runs 'ocpkg -v' after the first time, the bug will cause build to happen in 'pwd' instead of $OPENCOG_SOURCE_DIR

As a solution, I have added a 'cd $OPENCOG_SOURCE_DIR' command before 'git pull'. This will cause 'pwd' to be set to $OPENCOG_SOURCE_DIR and then 'git pull' fetches and merges in this new directory.

If my explanation is clear, feel free to ask. I'll try to explain in other words.
