### PR TITLE
Update libzmq and Python flask PPAs

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -96,6 +96,10 @@ LIVE_DESKTOP_SOURCE="OpenCog Source Code"
 
 REPOSITORIES="		
 		ppa:opencog-dev/ppa \
+                ppa:chris-lea/zeromq \
+                ppa:chris-lea/python-flask \
+                ppa:chris-lea/python-itsdangerous \
+                ppa:gandelman-a/test-catalog \
 		"
 		#opencog-dev: cxxtest
 
@@ -149,7 +153,7 @@ PACKAGES_BUILD="
 		tcl-dev \
 		tcsh \
 		uuid-dev \
-		libzmq-dev \
+		libzmq3-dev \
 		libprotoc-dev \
 		protobuf-compiler \
 		libcurl4-gnutls-dev \


### PR DESCRIPTION
Upgrade libzmq to version 3.2.4 instead of 2.1.11

As configured in https://github.com/githart/opencog-config-files/blob/master/docker/opencog/precise/ocpkg
