### PR TITLE
move the diffrent distro installation scripts here

### DIFF
--- a/install-archlinux-dependencies.sh
+++ b/install-archlinux-dependencies.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# This script is used for installing the dependencies required for
+# building opencog on archlinux.The script has been tested using docker
+# image base/archlinux:latest & l3iggs/archlinux
+# It is provided for those on 32-bit system or don't want to use
+# If you encounter an issue don't hesitate to supply a patch on github.
+
+# trap errors
+set -e
+
+# Environment Variables
+SELF_NAME=$(basename $0)
+
+PACKAGES_TOOLS="
+ 		git \
+		python-pip \
+		wget \
+		sudo \
+		pkg-config \
+		"
+
+# Packages for building opencog
+PACKAGES_BUILD="
+		gcc \
+		make \
+		cmake \
+		cxxtest \
+		rlwrap \
+		guile \
+		icu
+		bzip2 \
+		cython \
+		python2 \
+		python2-pyzmq \
+		python2-simplejson \
+		boost \
+        zeromq \
+        intel-tbb \
+        binutils \
+        gsl \
+        unixodbc \
+        protobuf \
+        protobuf-c \
+		sdl_gfx \
+		openssl \
+		tcl \
+		tcsh \
+		freetype2 \
+		blas \
+		lapack \
+		gcc-fortran \
+		"
+
+PACKAGES_RUNTIME="
+		unixodbc \
+		psqlodbc \
+		libpqxx \
+		"
+
+# Template for messages printed.
+message() {
+echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+}
+
+# Install  json-spirit (4.05)
+install_json_spirit(){
+MESSAGE="Installing json-spirit library...." ; message
+cd /tmp
+export BOOST_ROOT=/usr/include/boost/
+wget http://http.debian.net/debian/pool/main/j/json-spirit/json-spirit_4.05.orig.tar.gz
+tar -xvf json-spirit_4.05.orig.tar.gz
+cd json_spirit_v4_05
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf json-spirit_4.05.orig.tar.gz json_spirit_v4_05
+}
+
+# Install cogutils
+install_cogutil(){
+MESSAGE="Installing cogutils...." ; message
+cd /tmp/
+wget https://github.com/opencog/cogutils/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd cogutils-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf master.tar.gz cogutils-master/
+}
+
+# Install Python Packages
+install_python_packages(){
+MESSAGE="Installing python packages...." ; message
+cd /tmp
+wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
+sudo pip install -U -r /tmp/requirements.txt
+rm requirements.txt
+}
+
+# Install AtomSpace
+install_atomspace(){
+MESSAGE="Installing atomspace...." ; message
+cd /tmp/
+wget https://github.com/opencog/atomspace/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd atomspace-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf master.tar.gz atomspace-master/
+}
+
+# Function for installing all required dependenceis for building OpenCog,
+# as well as dependencies required for running opencog with other services.
+install_dependencies() {
+MESSAGE="Installing OpenCog build dependencies...." ; message
+if !  pacman -S --noconfirm $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_TOOLS; then
+  MESSAGE="Error installing some of dependencies... :( :("  ; message
+  exit 1
+fi
+install_python_packages
+install_json_spirit
+install_cogutil
+install_atomspace
+}
+
+# Main Program
+install_dependencies

--- a/install-debian-dependencies.sh
+++ b/install-debian-dependencies.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# This script is used for installing the dependencies required for
+# building opencog on debian.The script has been tested using docker
+# image debian:testing.
+# It is provided for those on 32-bit system or don't want to use
+# If you encounter an issue don't hesitate to supply a patch on github.
+
+# trap errors
+set -e
+
+# Environment Variables
+SELF_NAME=$(basename $0)
+
+# Some tools
+PACKAGES_TOOLS="
+		git \
+		python-pip \
+		wget \
+		sudo \
+		"
+
+# Packages for building opencog
+PACKAGES_BUILD="
+		build-essential \
+		cmake \
+		cxxtest \
+		rlwrap \
+		guile-2.0-dev \
+		libiberty-dev \
+		libicu-dev \
+		libbz2-dev \
+		cython \
+		python-dev \
+		python-zmq \
+		python-simplejson \
+		libboost-date-time-dev \
+		libboost-filesystem-dev \
+		libboost-math-dev \
+		libboost-program-options-dev \
+		libboost-regex-dev \
+		libboost-serialization-dev \
+		libboost-thread-dev \
+		libboost-system-dev \
+		libjson-spirit-dev \
+		libzmq3-dev \
+		libtbb-dev \
+		binutils-dev \
+		libgsl0-dev \
+		unixodbc-dev \
+		uuid-dev \
+		libprotoc-dev \
+		protobuf-compiler \
+		libsdl-gfx1.2-dev \
+		libssl-dev \
+		tcl-dev \
+		tcsh \
+		libfreetype6-dev \
+		libatlas-base-dev \
+		gfortran \
+		"
+
+# Packages required for integrating opencog with other services
+PACKAGES_RUNTIME="
+		unixodbc \
+		odbc-postgresql \
+		postgresql-client \
+		"
+
+# Template for messages printed.
+message() {
+echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+}
+
+# Install cogutils
+install_cogutil(){
+MESSAGE="Installing cogutils...." ; message
+cd /tmp/
+wget https://github.com/opencog/cogutils/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd cogutils-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf master.tar.gz cogutils-master/
+}
+
+# Install Python Packages
+install_python_packages(){
+MESSAGE="Installing python packages...." ; message
+cd /tmp
+wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
+sudo pip install -U -r /tmp/requirements.txt
+rm requirements.txt
+}
+
+# Install AtomSpace
+install_atomspace(){
+MESSAGE="Installing atomspace...." ; message
+cd /tmp/
+wget https://github.com/opencog/atomspace/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd atomspace-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf master.tar.gz atomspace-master/
+}
+
+# Function for installing all required dependenceis for building OpenCog,
+# as well as dependencies required for running opencog with other services.
+install_dependencies() {
+MESSAGE="Updating Package db...." ; message
+apt-get update
+
+MESSAGE="Installing OpenCog build dependencies...." ; message
+if ! (apt-get -y install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_TOOLS); then
+  MESSAGE="Error installing some of the dependencies... :( :("  ; message
+  exit 1
+fi
+install_python_packages
+install_cogutil
+install_atomspace
+}
+
+# Main Program
+install_dependencies

--- a/install-fedora-dependencies.sh
+++ b/install-fedora-dependencies.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+#
+# This script is used for installing the dependencies required for
+# building opencog on fedora.The script has been tested using docker
+# image fedora:21.
+# It is provided for those on 32-bit system or don't want to use
+# If you encounter an issue don't hesitate to supply a patch on github.
+
+# trap errors
+set -e
+
+# Environment Variables
+SELF_NAME=$(basename $0)
+
+# Some tools
+PACKAGES_TOOLS="
+        git \
+        python-pip \
+        wget \
+        tar \
+        sudo \
+		curl \
+            "
+
+# Packages for building opencog
+PACKAGES_BUILD="
+        make \
+        gcc \
+        gcc-c++ \
+        cmake \
+        cxxtest \
+        rlwrap \
+        guile-devel \
+        libicu-devel \
+        bzip2-devel \
+        Cython \
+        python-devel \
+        python-zmq \
+        boost-devel \
+        zeromq-devel \
+        tbb-devel \
+        binutils-devel \
+        gsl-devel \
+        unixODBC-devel \
+        uuid-devel \
+        protobuf-c \
+        protobuf-compiler \
+        SDL_gfx-devel \
+        openssl-devel \
+        tcl-devel \
+        tcsh \
+        freetype-devel \
+        atlas-devel \
+        gcc-gfortran \
+        "
+
+# Packages required for integrating opencog with other services
+PACKAGES_RUNTIME="
+        unixODBC \
+        postgresql-odbc \
+        postgresql-devel \
+        "
+
+# Template for messages printed.
+message() {
+echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+}
+
+# Install  json-spirit (4.05)
+install_json_spirit(){
+MESSAGE="Installing json-spirit library...." ; message
+cd /tmp
+export BOOST_ROOT=/usr/include/boost/
+wget http://http.debian.net/debian/pool/main/j/json-spirit/json-spirit_4.05.orig.tar.gz
+tar -xvf json-spirit_4.05.orig.tar.gz
+cd json_spirit_v4_05
+mkdir build
+cd build/
+cmake ..
+make -j"$(nproc)"
+sudo make install
+cd ../..
+rm -rf json-spirit_4.05.orig.tar.gz json_spirit_v4_05
+}
+
+# Install Python Packages
+install_opencog_python_packages(){
+MESSAGE="Installing python packages...." ; message
+cd /tmp
+wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
+sudo pip install -U -r /tmp/requirements.txt
+rm requirements.txt
+}
+
+# Install cogutils
+install_cogutil(){
+MESSAGE="Installing cogutils...." ; message
+cd /tmp/
+wget https://github.com/opencog/cogutils/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd cogutils-master/
+mkdir build
+cd build/
+cmake ..
+make -j"$(nproc)"
+sudo make install
+cd ../..
+rm -rf master.tar.gz cogutils-master/
+}
+
+# Install Link-Grammar
+install_link_grammar(){
+MESSAGE="Installing Link-Grammar...." ; message
+cd /tmp/
+# cleaning up remnants from previous install failures, if any.
+rm -rf link-grammar-5.*/
+wget -r --no-parent -nH --cut-dirs=2 http://www.abisource.com/downloads/link-grammar/current/
+tar -zxf current/link-grammar-5*.tar.gz
+rm -r current
+cd link-grammar-5.*/
+mkdir build
+cd build
+../configure
+make -j"$(nproc)"
+sudo make install
+sudo ldconfig
+cd /tmp/
+rm -rf link-grammar-5.*/
+cd $CURRENT_DIR
+}
+
+# Install AtomSpace
+install_atomspace(){
+MESSAGE="Installing atomspace...." ; message
+cd /tmp/
+wget https://github.com/opencog/atomspace/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd atomspace-master/
+mkdir build
+cd build/
+cmake ..
+make -j"$(nproc)"
+sudo make install
+cd ../..
+rm -rf master.tar.gz atomspace-master/
+}
+
+# Function for installing all required dependenceis for building OpenCog,
+# as well as dependencies required for running opencog with other services.
+install_dependencies() {
+MESSAGE="Updating Package db...." ; message
+dnf updateinfo
+
+MESSAGE="Installing OpenCog build dependencies...." ; message
+if !  (sudo dnf -y install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_TOOLS)
+then
+  MESSAGE="Error installing some of dependencies... :( :("  ; message
+  exit 1
+fi
+install_json_spirit
+}
+
+# Install Haskell Dependencies
+install_haskell_dependencies(){
+if ! is_x68_64_fedora_22; then
+MESSAGE="Installing haskell dependencies in user space...." ; message
+# Install stack.
+curl -sSL https://s3.amazonaws.com/download.fpcomplete.com/fedora/22/fpco.repo | sudo tee /etc/yum.repos.d/fpco.repo
+sudo dnf -y install stack
+fi
+
+# Notes
+# 1. Stack setup must me run in user space:
+#    "stack setup" looks for proper ghc version in the system according to the
+#    information provided by stack.yaml. If it is not installed, it attempts to
+#    install proper ghc version on user space (~/.stack/...). Because of that,
+#    it must not be run as root.
+
+# 2. Difference b/n .cabal and stack.yaml:
+#    The .cabal file contains package metadata, in this case
+#    "opencog-atomspace.cabal" contains information of the opencog-atomspace
+#    package (autor, license, dependencies, etc.). The stack.yaml file contains
+#    configuration options for the stack building tool, we use it to set the
+#    proper "long term support" snapshot that we are using, which determines the
+#    proper ghc version to use, etc. In this case, it doesn't make sense to
+#    require the .cabal file, because we are not using that information to build
+#    the hscolour package, but it looks like stack always looks for a .cabal
+#    file when building, even though, in this case, it doesn't use it.
+if [ "$EUID" -ne 0 ] ; then
+    cd /tmp
+    wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/stack.yaml
+    wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/opencog-atomspace.cabal
+    stack setup
+
+    # hscolour is necessary for haddock documentation.
+    stack build hscolour --copy-bins
+    rm stack.yaml opencog-atomspace.cabal
+    cd $CURRENT_DIR
+else
+    echo "Please run without sudo. Stack need to be run in non-root user space."
+fi
+}
+
+usage() {
+echo "Usage: $SELF_NAME OPTION"
+echo " -d Install base/system build dependencies"
+echo " -p Install opencog python build dependencies"
+echo " -s Install haskell build dependencies in user space. Don't use sudo"
+echo " -c Install Cogutils"
+echo " -a Install Atomspace"
+echo " -l Install Link Grammar"
+echo " -h This help message"
+}
+
+# Main Program
+if [ $# -eq 0 ] ; then NO_ARGS=true ; fi
+
+while getopts "dpcalsh" flag ; do
+    case $flag in
+      d)    INSTALL_DEPENDENCIES=true ;; #base development packages
+      p)    INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
+      c)    INSTALL_COGUTIL=true ;;
+      a)    INSTALL_ATOMSPACE=true ;;
+      l)    INSTALL_LINK_GRAMMAR=true ;;
+      s)    HASKELL_STACK_SETUP=true;;
+      h)    usage ;;
+      \?)    usage ;;
+      *)  UNKNOWN_FLAGS=true ;;
+    esac
+done
+
+if [ $INSTALL_DEPENDENCIES ] ; then install_dependencies ; fi
+if [ $HASKELL_STACK_SETUP ] ; then install_haskell_dependencies ; fi
+if [ $INSTALL_OPENCOG_PYTHON_PACKAGES ] ; then
+    install_opencog_python_packages
+fi
+if [ $INSTALL_COGUTIL ] ; then install_cogutil ; fi
+if [ $INSTALL_ATOMSPACE ] ; then install_atomspace ; fi
+if [ $INSTALL_LINK_GRAMMAR ] ; then install_link_grammar ; fi
+if [ $UNKNOWN_FLAGS ] ; then usage ; fi
+if [ $NO_ARGS ] ; then usage ; fi

--- a/install-opensuse-dependencies.sh
+++ b/install-opensuse-dependencies.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+# This script is used for installing the dependencies required for
+# building opencog on openSUSE.The script has been tested using docker
+# image opensuse:13.2
+# It is provided for those on 32-bit system or don't want to use
+# If you encounter an issue don't hesitate to supply a patch on github.
+
+# TODO Make it work
+
+# trap errors
+set -e
+
+# Environment Variables
+SELF_NAME=$(basename $0)
+
+# Some tools
+PACKAGES_TOOLS="
+		git \
+		python-pip \
+		wget \
+		"
+
+# Packages for building opencog
+# FIXME cxxtest and tbb are not installaed
+PACKAGES_BUILD="
+		gcc \
+		make \
+		cmake \
+		cxxtest \
+		rlwrap \
+		guile \
+		libicu-devel \
+		libzip2 \
+		python-Cython \
+		python-devel \
+		python-pyzmq \
+		python-simplejson \
+		boost-devel \
+		libzmq3 \
+		zeromq-devel \
+		binutils-devel \
+		libgsl0 gsl-devel \
+		unixodbc-devel \
+		uuid-devel \
+		libprotobuf-c-devel \
+		libSDL_gfx-devel \
+		libssl27 \
+		tcl  \
+		tcsh \
+		freetype2-devel \
+		libatlas3 \
+		gcc-fortran \
+		"
+
+# Packages required for integrating opencog with other services
+PACKAGES_RUNTIME="
+		unixODBC-devel \
+		psqlODBC \
+		postgresql \
+		"
+
+# Template for messages printed.
+message() {
+echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+}
+
+# Install  json-spirit (4.05)
+install_json_spirit(){
+MESSAGE="Installing json-spirit library...." ; message
+cd /tmp
+export BOOST_ROOT=/usr/include/boost/
+wget http://http.debian.net/debian/pool/main/j/json-spirit/json-spirit_4.05.orig.tar.gz
+tar -xvf json-spirit_4.05.orig.tar.gz
+cd json_spirit_v4_05
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf json-spirit_4.05.orig.tar.gz json_spirit_v4_05
+}
+
+# Install cogutils
+install_cogutil(){
+MESSAGE="Installing cogutils...." ; message
+cd /tmp/
+wget https://github.com/opencog/cogutils/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd cogutils-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf master.tar.gz cogutils-master/
+}
+
+# Install Python Packages
+install_python_packages(){
+MESSAGE="Installing python packages...." ; message
+cd /tmp
+wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
+sudo pip install -U -r /tmp/requirements.txt
+rm requirements.txt
+}
+
+# Install AtomSpace
+install_atomspace(){
+MESSAGE="Installing atomspace...." ; message
+cd /tmp/
+wget https://github.com/opencog/atomspace/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd atomspace-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+cd ../..
+rm -rf master.tar.gz atomspace-master/
+}
+
+# Function for installing all required dependenceis for building OpenCog,
+# as well as dependencies required for running opencog with other services.
+install_dependencies() {
+MESSAGE="Installing OpenCog build dependencies...." ; message
+# FIXME Haven't figured out which package is making this check fail.
+if ! (zypper --no-refresh install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_TOOLS);
+then
+  MESSAGE="Error installing some of dependencies... :( :("  ; message
+  exit 1
+fi
+install_json_spirit
+install_python_packages
+install_cogutil
+install_atomspace
+}
+
+# Main Program
+install_dependencies


### PR DESCRIPTION
the scripts could be used for setting up the various
sub-repos under the opencog developement thus need to
be in their own separte repo, which this repo is for