### PR TITLE
Quick Fix for Debian

### DIFF
--- a/install-debian-dependencies.sh
+++ b/install-debian-dependencies.sh
@@ -136,7 +136,7 @@ fi
 install_dependencies
 install_python_packages
 
-echo "Dependencies installed, we can clone OpenCog, Atomspace, etc to the current directory if you like.
+echo "Dependencies installed, we can clone OpenCog, Atomspace, etc to the current directory if you like."
 read -p "Download Opencog source to current path? (y/n) " gitclone
 if [ "$gitclone" == "y" ] || [ "$gitclone" == "Y" ]
 then

--- a/install-debian-dependencies.sh
+++ b/install-debian-dependencies.sh
@@ -129,12 +129,17 @@ fi
 
 # Main Program
 install_dependencies
+install_python_packages
 
-read -p "Dependencies installed, would you like to attempt an autoinstall of opencog? (y/n) " instprompt
-if [ $instprompt !== "y"]
+echo "Dependencies installed, we can clone OpenCog, Atomspace, etc to the current directory if you like.
+read -p "Download Opencog source to current path? (y/n) " gitclone
+if [ "$gitclone" == "y" ] || [ "$gitclone" == "Y" ]
 then
+	git clone https://github.com/opencog/opencog.git
+	git clone https://github.com/opencog/atomspace.git
+	git clone https://github.com/opencog/cogutils.git
+else
+	echo "Download of OpenCog aborted."
 	exit
 fi
-git clone https://github.com/opencog/opencog.git
-git clone https://github.com/opencog/atomspace.git
-git clone https://github.com/opencog/cogutils.git
+

--- a/install-debian-dependencies.sh
+++ b/install-debian-dependencies.sh
@@ -136,6 +136,7 @@ fi
 install_dependencies
 install_python_packages
 
+printf '\n \n'
 echo "Dependencies installed, we can clone OpenCog, Atomspace, etc to the current directory if you like."
 read -p "Download Opencog source to current path? (y/n) " gitclone
 if [ "$gitclone" == "y" ] || [ "$gitclone" == "Y" ]

--- a/install-debian-dependencies.sh
+++ b/install-debian-dependencies.sh
@@ -90,6 +90,8 @@ rm -rf master.tar.gz cogutils-master/
 install_python_packages(){
 MESSAGE="Installing python packages...." ; message
 cd /tmp
+#Fix for sslv3 Debian error
+sudo easy_install --upgrade pip
 wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
 sudo pip install -U -r /tmp/requirements.txt
 rm requirements.txt
@@ -142,4 +144,6 @@ else
 	echo "Download of OpenCog aborted."
 	exit
 fi
+
+echo "You should now be able to build according to the OpenCog for noobs instructions. Good luck!"
 

--- a/install-debian-dependencies.sh
+++ b/install-debian-dependencies.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 #
-#Last Edit 11/11/2015 by Noah Bliss. Forked due to broken build process.
-#Script is designed to interactively install opencog on a clean Debian Jessie environment.
+#Script is designed to interactively install opencog dependencies on a clean Debian Jessie environment.
+#Last Edit 11/11/2015 by Noah Bliss. Forked due to broken build process/Debian Python issues.
+#Repaired apt/python deps installs. 
+#Disabled cogutil/atomspace build/install to make "Installing_OpenCog_for_Noobs" intructions valid.
+#Script then optionally does a git clone from the OpenCog github.
 # If you encounter an issue don't hesitate to supply a patch on github.
 
 # trap errors

--- a/install-debian-dependencies.sh
+++ b/install-debian-dependencies.sh
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
-# This script is used for installing the dependencies required for
-# building opencog on debian.The script has been tested using docker
-# image debian:testing.
-# It is provided for those on 32-bit system or don't want to use
+#Last Edit 11/11/2015 by Noah Bliss. Forked due to broken build process.
+#Script is designed to interactively install opencog on a clean Debian Jessie environment.
 # If you encounter an issue don't hesitate to supply a patch on github.
 
 # trap errors
@@ -124,10 +122,19 @@ if ! (apt-get -y install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_TOOLS); the
   MESSAGE="Error installing some of the dependencies... :( :("  ; message
   exit 1
 fi
-install_python_packages
-install_cogutil
-install_atomspace
+#install_python_packages
+#install_cogutil
+#install_atomspace
 }
 
 # Main Program
 install_dependencies
+
+read -p "Dependencies installed, would you like to attempt an autoinstall of opencog? (y/n) " instprompt
+if [ $instprompt !== "y"]
+then
+	exit
+fi
+git clone https://github.com/opencog/opencog.git
+git clone https://github.com/opencog/atomspace.git
+git clone https://github.com/opencog/cogutils.git


### PR DESCRIPTION
Seeing as developers are somewhat spread thin and primary focus is developing for Ubuntu, I updated the Debian script. It downloads the dependencies it can from apt and also installs the python deps, however it no longer installs atomspace or cogutils. Rather, it optionally allows git cloning of the required code to easily complete the "Installing OpenCog for Noobs" instructions. This should allow us to update this script less frequently, but at the same time allow users to build for Debian successfully. I eventually plan on modifying ocpkg for Debian or writing a build script from scratch later. In the short term, this does the job. 