### PR TITLE
start separating octool from ocpkg

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 ## @file		ocpkg
-## @copyright		OpenCog Foundation (2012,2013,2014)
+## @copyright		OpenCog Foundation (2012,2013,2014,2015)
 ## @author		David Hart <dhart@opencog.org>
 ## @section DESCRIPTION	A script to download, build, test, install and package OpenCog
 ## @section LICENSE	Permission to copy and modify is granted under the GPL

--- a/ocpkg
+++ b/ocpkg
@@ -550,7 +550,7 @@ for REPO in $REPOSITORIES ; do
 done
 
 # Ros repository for opencog/opencog repo
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
 sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-key 0xB01FA116
 
 sudo apt-get $QUIET --assume-yes update

--- a/octool
+++ b/octool
@@ -133,29 +133,10 @@ PACKAGES_EXDEV="
         python-bzrlib \
         linux-headers-generic \
         "
-  --disable-legacy-registry=false
-usage() {
-    printf "Usage: $SELF_NAME [OPTION] \n"
-    printf "Options: \n"
-    printf "  -r Add software repositories \n"
-    printf "  -d Install base/system build dependencies \n"
-    printf "  -p Install python build dependencies \n"
-    printf "  -s Install haskell build dependencies in user space \n"
-    printf "  -i Install build-job artifacts \n"
-    printf "  -c Install Cogutils \n"
-    printf "  -a Install Atomspace \n"
-    printf "  -l Install Link Grammar \n"
-    printf "  -m Install MOSES \n"
-    printf "  -b Build source code in git worktree found @ $PWD \n"
-    printf "  -e Build examples in git worktree found @ $PWD \n"
-    printf "  -t Run tests of source code in git worktree found @ $PWD \n"
-    printf "  -j [jobs] override number of auto-detected make jobs \n"
-    printf "  -v Verbose output for 'apt-get' commands \n"
-    printf "  -h This help message \n"
-}
+
 
 message() {
-    printf -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+    printf "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m \n"
 }
 
 is_x68_64_trusty() {
@@ -490,59 +471,96 @@ update_opencog_source() {
     fi
 }
 
-build_opencog() {
-    mkdir -p -v $LIVE_BUILD_DIR || true
-    cd $LIVE_BUILD_DIR
-    MESSAGE="cmake $LIVE_SOURCE_BRANCH" ; message
-    cmake $LIVE_SOURCE_BRANCH
-    MESSAGE="make -j$MAKE_JOBS" ; message
-    make -j$MAKE_JOBS
+# build_opencog() {
+#     mkdir -p -v $LIVE_BUILD_DIR || true
+#     cd $LIVE_BUILD_DIR
+#     MESSAGE="cmake $LIVE_SOURCE_BRANCH" ; message
+#     cmake $LIVE_SOURCE_BRANCH
+#     MESSAGE="make -j$MAKE_JOBS" ; message
+#     make -j$MAKE_JOBS
+#
+#     if [ $TEST_OPENCOG ] ; then
+#       make test
+#     fi
+#
+#     case $PACKAGE_TYPE in
+#       min)    MESSAGE="Installing OpenCog..." ; message
+#          make install; exit 0;;
+#       demo)    MESSAGE="Installing OpenCog..." ; message
+#           make install; exit 0;;
+#       dev)    exit 0;;
+#     esac
+#
+# }
 
-    if [ $TEST_OPENCOG ] ; then
-      make test
-    fi
-
-    case $PACKAGE_TYPE in
-      min)    MESSAGE="Installing OpenCog..." ; message
-         make install; exit 0;;
-      demo)    MESSAGE="Installing OpenCog..." ; message
-          make install; exit 0;;
-      dev)    exit 0;;
-    esac
-
+usage() {
+    printf "Usage: %s %s [OPTION] \n" $SELF_NAME $COMMAND_MODE_CHOSEN
+    printf "Options: \n"
+    printf "  -r Add software repositories \n"
+    printf "  -d Install base/system build dependencies \n"
+    printf "  -p Install python build dependencies \n"
+    printf "  -s Install haskell build dependencies in user space \n"
+    printf "  -i Install build-job artifacts \n"
+    printf "  -c Install Cogutils \n"
+    printf "  -a Install Atomspace \n"
+    printf "  -l Install Link Grammar \n"
+    printf "  -m Install MOSES \n"
+    printf "  -b Build source code in git worktree found @ %s \n" $PWD
+    printf "  -e Build examples in git worktree found @ %s \n" $PWD
+    printf "  -t Run tests of source code in git worktree found @ %s \n" $PWD
+    printf "  -j [jobs] override number of auto-detected make jobs \n"
+    printf "  -v Verbose output for 'apt-get' commands \n"
+    printf "  -h This help message \n"
 }
 
-
+# Main Program (MAIN main):
 # TODO: change octool usage to 'octool project command' format. Where projects
 # are opencog, atomspace, cogutils... & commands are setup(for workspace),
 # package(for docker,deb, rpm). Each will have various options/sub-commands.
-#if [ $1 ] && [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
+declare -A COMMAND_MODE_DESCRIPTION=(
+    #simple is compatible previous octool
+    [simple]="Intended for deployment and backward compatability"
+    [dev]="This mode is WIP and is intended for developers"
+)
 
-if [ $# -eq 0 ] ; then NO_ARGS=true ; fi
+case $1 in
+    simple) COMMAND_MODE_CHOSEN=simple ;;
+    dev) COMMAND_MODE_CHOSEN=dev ;;
+    *) MESSAGE="Modes available are: ${!COMMAND_MODE_DESCRIPTION[@]}" ; message
+       exit 1 ;;
+esac
 
-while getopts "abdeipcrstlmhvj:" flag ; do
-    case $flag in
-      r) ADD_REPOSITORIES=true ;;
-      d) INSTALL_DEPENDENCIES=true ;; #base development packages
-      p) INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
-      c) INSTALL_COGUTIL=true ;;
-      a) INSTALL_ATOMSPACE=true ;;
-      l) INSTALL_LINK_GRAMMAR=true ;;
-      m) INSTALL_MOSES=true ;;
-      b) BUILD_SOURCE=true ;;
-      e) BUILD_EXAMPLES=true ;;
-      t) TEST_SOURCE=true ;;
-      v) unset QUIET ;;
-      j) MAKE_JOBS="$OPTARG" ;;
-      s) HASKELL_STACK_SETUP=true;;
-      i) INSTALL_BUILD=true ;;
-      h) usage ;;
-      \?) usage ;;
-      *)  UNKNOWN_FLAGS=true ;;
-    esac
-done
+case $COMMAND_MODE_CHOSEN in
+    simple)
+        echo $# "argument nu"
+        shift
+        if [ $# -eq 0 ] ; then usage ; exit 0 ; fi
+        while getopts "abdeipcrstlmhvj:" flag ; do
+            case $flag in
+              r) ADD_REPOSITORIES=true ;;
+              d) INSTALL_DEPENDENCIES=true ;;
+              p) INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
+              c) INSTALL_COGUTIL=true ;;
+              a) INSTALL_ATOMSPACE=true ;;
+              l) INSTALL_LINK_GRAMMAR=true ;;
+              m) INSTALL_MOSES=true ;;
+              b) BUILD_SOURCE=true ;;
+              e) BUILD_EXAMPLES=true ;;
+              t) TEST_SOURCE=true ;;
+              v) unset QUIET ;;
+              j) MAKE_JOBS="$OPTARG" ;;
+              s) HASKELL_STACK_SETUP=true;;
+              i) INSTALL_BUILD=true ;;
+              h) usage ;;
+              \?) usage ;;
+              *)  UNKNOWN_FLAGS=true ;;
+            esac
+        done
+        ;;
+    dev) printf "WIP comming soon :-) \n" ;;
+esac
 
-# Main Program (MAIN main):
+
 # This is mainly for configuring workspaces depending on the type
 # of project being worked on. The order here matters.
 if [ $ADD_REPOSITORIES ] ; then add_repositories ; fi
@@ -558,5 +576,4 @@ if [ $BUILD_EXAMPLES ] ; then build_examples ; fi
 if [ $TEST_SOURCE ] ; then test_source ; fi
 if [ $INSTALL_BUILD ] ; then install_build ; fi
 if [ $UNKNOWN_FLAGS ] ; then usage ; fi
-if [ $NO_ARGS ] ; then usage ; fi
 exit 0

--- a/octool
+++ b/octool
@@ -15,9 +15,7 @@ MAKE_JOBS=$(($PROCESSORS+0))
 VERBOSE="-v"
 QUIET="-qq"
 
-REPOSITORIES="
-        ppa:opencog-dev/ppa \
-        "
+REPOSITORIES=""
 
 PACKAGES_FETCH="
         python-pip \
@@ -494,7 +492,7 @@ update_opencog_source() {
 # }
 
 usage() {
-    printf "Usage: %s %s [OPTION] \n" $SELF_NAME $COMMAND_MODE_CHOSEN
+    printf "Usage: %s %s [OPTION] project\n" $SELF_NAME $COMMAND_MODE_CHOSEN
     printf "Options: \n"
     printf "  -r Add software repositories \n"
     printf "  -d Install base/system build dependencies \n"
@@ -517,10 +515,16 @@ usage() {
 # TODO: change octool usage to 'octool project command' format. Where projects
 # are opencog, atomspace, cogutils... & commands are setup(for workspace),
 # package(for docker,deb, rpm). Each will have various options/sub-commands.
+#
 declare -A COMMAND_MODE_DESCRIPTION=(
     #simple is compatible previous octool
     [simple]="Intended for deployment and backward compatability"
-    [dev]="This mode is WIP and is intended for developers"
+    # TODO Dev should be distro aware, that is, arch vs debian vs fedora
+    # shouldn't be an issue. If a dependancy doesn't exist through the distro
+    # then it should build from source.
+    [dev]="This mode is for configuring development space"
+    [build]="This is for building sources"
+    [run]="Run test or cogserver or some other thing"
 )
 
 case $1 in
@@ -532,7 +536,6 @@ esac
 
 case $COMMAND_MODE_CHOSEN in
     simple)
-        echo $# "argument nu"
         shift
         if [ $# -eq 0 ] ; then usage ; exit 0 ; fi
         while getopts "abdeipcrstlmhvj:" flag ; do

--- a/octool
+++ b/octool
@@ -316,6 +316,21 @@ build_examples() {
     MESSAGE="Finished building examples" ; message
 }
 
+# Build tests function for opencog, atomspace, moses & cogutils repos
+build_tests() {
+    set_source_and_build_dir
+    if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+        rm $BUILD_DIR/CMakeCache.txt
+        MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
+    fi
+    MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
+    #stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+    cmake -B$BUILD_DIR -H$SOURCE_DIR
+    MESSAGE="make -C $BUILD_DIR  -j$MAKE_JOBS tests" ; message
+    make -C $BUILD_DIR -j$MAKE_JOBS tests
+    MESSAGE="Finished building tests" ; message
+}
+
 # Run tests function for opencog, atomspace, moses & cogutils repos
 test_source() {
     #check if gearman service is running, start it if not
@@ -530,6 +545,7 @@ declare -A COMMAND_MODE_DESCRIPTION=(
 case $1 in
     simple) COMMAND_MODE_CHOSEN=simple ;;
     dev) COMMAND_MODE_CHOSEN=dev ;;
+    build) COMMAND_MODE_CHOSEN=build ;;
     *) MESSAGE="Modes available are: ${!COMMAND_MODE_DESCRIPTION[@]}" ; message
        exit 1 ;;
 esac
@@ -561,6 +577,23 @@ case $COMMAND_MODE_CHOSEN in
         done
         ;;
     dev) printf "WIP comming soon :-) \n" ;;
+    build)
+        shift
+        if [ $# -eq 0 ] ; then usage ; exit 0 ; fi
+        while getopts "aehstj:" flag ; do
+            case $flag in
+              a) BUILD_ALL=true ;;
+              s) BUILD_SOURCE=true ;;
+              e) BUILD_EXAMPLES=true ;;
+              t) BUILD_TESTS=true ;;
+              j) MAKE_JOBS="$OPTARG" ;;
+              h) usage ;;
+              \?) usage ;;
+              *)  UNKNOWN_FLAGS=true ;;
+            esac
+        done
+        ;;
+    *) echo "Try the defaults" ; exit 1;;
 esac
 
 
@@ -574,8 +607,14 @@ if [ $INSTALL_COGUTIL ] ; then install_cogutil ; fi
 if [ $INSTALL_ATOMSPACE ] ; then install_atomspace ; fi
 if [ $INSTALL_LINK_GRAMMAR ] ; then install_link_grammar ; fi
 if [ $INSTALL_MOSES ] ; then install_moses ; fi
+if [ $BUILD_ALL ] ; then
+    build_source
+    build_examples
+    build_tests
+fi
 if [ $BUILD_SOURCE ] ; then build_source ; fi
 if [ $BUILD_EXAMPLES ] ; then build_examples ; fi
+if [ $BUILD_TESTS ] ; then build_tests ; fi
 if [ $TEST_SOURCE ] ; then test_source ; fi
 if [ $INSTALL_BUILD ] ; then install_build ; fi
 if [ $UNKNOWN_FLAGS ] ; then usage ; fi

--- a/octool
+++ b/octool
@@ -159,7 +159,7 @@ add_repositories() {
     done
 
     # Ros repository for opencog/opencog repo
-    sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+    sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
     sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-key 0xB01FA116
 
     sudo apt-get $QUIET --assume-yes update

--- a/octool
+++ b/octool
@@ -133,28 +133,29 @@ PACKAGES_EXDEV="
         python-bzrlib \
         linux-headers-generic \
         "
-
+  --disable-legacy-registry=false
 usage() {
-    echo "Usage: $SELF_NAME OPTION"
-    echo " -r Add software repositories"
-    echo " -d Install base/system build dependencies"
-    echo " -p Install python build dependencies"
-    echo " -s Install haskell build dependencies in user space. Don't use sudo"
-    echo " -i Install build-job artifacts"
-    echo " -c Install Cogutils"
-    echo " -a Install Atomspace"
-    echo " -l Install Link Grammar"
-    echo " -m Install MOSES"
-    echo " -b Build source code in git worktree found @ $PWD"
-    echo " -e Build examples in git worktree found @ $PWD"
-    echo " -t Run tests of source code in git worktree found @ $PWD"
-    echo " -j [jobs] override number of auto-detected make jobs"
-    echo " -v Verbose output for 'apt-get' commands"
-    echo " -h This help message"
+    printf "Usage: $SELF_NAME [OPTION] \n"
+    printf "Options: \n"
+    printf "  -r Add software repositories \n"
+    printf "  -d Install base/system build dependencies \n"
+    printf "  -p Install python build dependencies \n"
+    printf "  -s Install haskell build dependencies in user space \n"
+    printf "  -i Install build-job artifacts \n"
+    printf "  -c Install Cogutils \n"
+    printf "  -a Install Atomspace \n"
+    printf "  -l Install Link Grammar \n"
+    printf "  -m Install MOSES \n"
+    printf "  -b Build source code in git worktree found @ $PWD \n"
+    printf "  -e Build examples in git worktree found @ $PWD \n"
+    printf "  -t Run tests of source code in git worktree found @ $PWD \n"
+    printf "  -j [jobs] override number of auto-detected make jobs \n"
+    printf "  -v Verbose output for 'apt-get' commands \n"
+    printf "  -h This help message \n"
 }
 
 message() {
-    echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+    printf -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
 }
 
 is_x68_64_trusty() {
@@ -281,7 +282,8 @@ install_haskell_dependencies(){
         rm stack.yaml opencog-atomspace.cabal
         cd $CURRENT_DIR
     else
-        echo "Please run without sudo. Stack need to be run in non-root user space."
+        printf "Please run without sudo. Stack need to be run in non-root user space."
+        exit 1
     fi
 }
 
@@ -468,7 +470,7 @@ install_dependencies() {
 
 update_opencog_source() {
     if sudo apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_FETCH ; then
-      echo -n
+      printf "\n"
     else
       MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
     exit 1

--- a/octool
+++ b/octool
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-## @file		octool
-## @copyright		OpenCog Foundation 2016
-## @section DESCRIPTION	A script to download, build, test, install and
+## @file        octool
+## @copyright        OpenCog Foundation 2016
+## @section DESCRIPTION    A script to download, build, test, install and
 ##          configure OpenCog projects
 
 # trap errors
@@ -16,124 +16,123 @@ VERBOSE="-v"
 QUIET="-qq"
 
 REPOSITORIES="
-		ppa:opencog-dev/ppa \
-		"
+        ppa:opencog-dev/ppa \
+        "
 
 PACKAGES_FETCH="
         python-pip \
-		git \
-			"
+        git \
+            "
 
 PACKAGES_BUILD="
-		build-essential \
-		cmake \
-		cxxtest \
-		rlwrap \
-		guile-2.0-dev \
-		libiberty-dev \
-		libicu-dev \
-		libbz2-dev \
-		cython \
-		python-dev \
-		python-zmq \
-		python-simplejson \
-		libboost-date-time-dev \
-		libboost-filesystem-dev \
-		libboost-math-dev \
-		libboost-program-options-dev \
-		libboost-regex-dev \
-		libboost-serialization-dev \
-		libboost-thread-dev \
-		libboost-system-dev \
-		libboost-random-dev \
-		libjson-spirit-dev \
-		libzmq3-dev \
-		libtbb-dev \
-		binutils-dev \
-		unixodbc-dev \
-		uuid-dev \
-		libprotoc-dev \
-		protobuf-compiler \
-		libsdl-gfx1.2-dev \
-		libssl-dev \
-		tcl-dev \
-		tcsh \
-		libfreetype6-dev \
-		libatlas-base-dev \
-		gfortran \
-		gearman \
-		libgearman-dev \
-		ros-indigo-octomap \
-		"
+        build-essential \
+        cmake \
+        cxxtest \
+        rlwrap \
+        guile-2.0-dev \
+        libiberty-dev \
+        libicu-dev \
+        libbz2-dev \
+        cython \
+        python-dev \
+        python-zmq \
+        python-simplejson \
+        libboost-date-time-dev \
+        libboost-filesystem-dev \
+        libboost-math-dev \
+        libboost-program-options-dev \
+        libboost-regex-dev \
+        libboost-serialization-dev \
+        libboost-thread-dev \
+        libboost-system-dev \
+        libboost-random-dev \
+        libjson-spirit-dev \
+        libzmq3-dev \
+        libtbb-dev \
+        binutils-dev \
+        unixodbc-dev \
+        uuid-dev \
+        libprotoc-dev \
+        protobuf-compiler \
+        libsdl-gfx1.2-dev \
+        libssl-dev \
+        tcl-dev \
+        tcsh \
+        libfreetype6-dev \
+        libatlas-base-dev \
+        gfortran \
+        gearman \
+        libgearman-dev \
+        ros-indigo-octomap \
+        "
 
 PACKAGES_RUNTIME="
-		unixodbc \
-		odbc-postgresql \
-		postgresql-client \
-		"
+        unixodbc \
+        odbc-postgresql \
+        postgresql-client \
+        "
 
 PACKAGES_DOC="
-		ubuntu-docs \
-		libglib2.0-doc \
-		libpango1.0-doc \
-		libgtk-3-doc \
-		texlive-latex-base-doc \
-		python-doc \
-		devhelp-common \
-		texlive-doc-base \
-		doxygen \
- 		dot2tex \
-		"
+        ubuntu-docs \
+        libglib2.0-doc \
+        libpango1.0-doc \
+        libgtk-3-doc \
+        texlive-latex-base-doc \
+        python-doc \
+        devhelp-common \
+        texlive-doc-base \
+        doxygen \
+        dot2tex \
+        "
 
 PACKAGES_EXDEV="
-		autoconf automake autotools-dev \
-		blt \
-		comerr-dev \
-		dpkg-dev \
-		emacsen-common \
-		fakeroot \
-		gettext \
-		gdb \
-		g++-4.6 \
-		gcc-4.6 \
-		krb5-multidev \
-		libc6-dev \
-		libdpkg-perl \
-		libdpkg-perl \
-		libgcrypt11-dev \
-		libglade2-0 \
-		libgnutls-dev \
-		libgpg-error-dev \
-		libgssrpc4 \
-		libidn11-dev \
-		libalgorithm-diff-perl \
-		libalgorithm-diff-xs-perl \
-		libalgorithm-merge-perl \
-		libkadm5clnt-mit8 \
-		libkadm5srv-mit8 \
-		libkrb5-dev \
-		libldap2-dev \
-		libltdl-dev \
-		libstdc++6-4.6-dev \
-		libtasn1-3-dev \
-		libtimedate-perl \
-		libtool \
-		libunistring0 \
-		libxss1 \
-		make \
-		manpages-dev \
-		m4 \
-		patch \
-		python-glade2 \
-		python-tk \
-		tcl8.5 \
-		tk8.5 \
-		ttf-lyx \
-		zlib1g-dev \
-		python-bzrlib \
-		linux-headers-generic \
-		"
-
+        autoconf automake autotools-dev \
+        blt \
+        comerr-dev \
+        dpkg-dev \
+        emacsen-common \
+        fakeroot \
+        gettext \
+        gdb \
+        g++-4.6 \
+        gcc-4.6 \
+        krb5-multidev \
+        libc6-dev \
+        libdpkg-perl \
+        libdpkg-perl \
+        libgcrypt11-dev \
+        libglade2-0 \
+        libgnutls-dev \
+        libgpg-error-dev \
+        libgssrpc4 \
+        libidn11-dev \
+        libalgorithm-diff-perl \
+        libalgorithm-diff-xs-perl \
+        libalgorithm-merge-perl \
+        libkadm5clnt-mit8 \
+        libkadm5srv-mit8 \
+        libkrb5-dev \
+        libldap2-dev \
+        libltdl-dev \
+        libstdc++6-4.6-dev \
+        libtasn1-3-dev \
+        libtimedate-perl \
+        libtool \
+        libunistring0 \
+        libxss1 \
+        make \
+        manpages-dev \
+        m4 \
+        patch \
+        python-glade2 \
+        python-tk \
+        tcl8.5 \
+        tk8.5 \
+        ttf-lyx \
+        zlib1g-dev \
+        python-bzrlib \
+        linux-headers-generic \
+        "
 
 usage() {
     echo "Usage: $SELF_NAME OPTION"
@@ -154,6 +153,363 @@ usage() {
     echo " -h This help message"
 }
 
+message() {
+    echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+}
+
+is_x68_64_trusty() {
+    OSREL=$(sed -n 's/DISTRIB_CODENAME=\(.*\)/\1/p' /etc/lsb-release);
+    ARCH=$(uname -m);
+    if [ "$OSREL" == "trusty" -a "$ARCH" == "x86_64" ]; then
+      return 0
+    else
+      return 1
+    fi
+}
+
+add_stack_repository() {
+    wget -q -O- https://s3.amazonaws.com/download.fpcomplete.com/ubuntu/fpco.key | sudo apt-key add -
+    echo 'deb http://download.fpcomplete.com/ubuntu/trusty stable main' | sudo tee /etc/apt/sources.list.d/fpco.list
+}
+
+add_repositories() {
+    MESSAGE="Adding software repositories..." ; message
+    for REPO in $REPOSITORIES ; do
+      sudo apt-add-repository -y $REPO
+    done
+
+    # Ros repository for opencog/opencog repo
+    sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+    sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-key 0xB01FA116
+
+    sudo apt-get $QUIET --assume-yes update
+}
+
+install_admin() {
+    MESSAGE="Installing sysadmin tools...." ; message
+    if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_ADMIN ; then
+      MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
+      exit 1
+    fi
+}
+
+# Install cogutils
+install_cogutil(){
+    MESSAGE="Installing cogutils...." ; message
+    cd /tmp/
+    # cleaning up remnants from previous install failures, if any.
+    rm -rf master.tar.gz* cogutils-master
+    wget https://github.com/opencog/cogutils/archive/master.tar.gz
+    tar -xvf master.tar.gz
+    cd cogutils-master/
+    mkdir build
+    cd build/
+    cmake ..
+    make -j$(nproc)
+    sudo make install
+    sudo ldconfig
+    cd /tmp/
+    rm -rf master.tar.gz cogutils-master/
+    cd $CURRENT_DIR
+}
+
+# Install Python Packages
+install_opencog_python_packages(){
+    MESSAGE="Installing python packages...." ; message
+    cd /tmp
+    # cleaning up remnants from previous install failures, if any.
+    rm -f requirements.txt*
+    wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
+    # scipy, numpy & matplotlib if installed using python-pip will take a
+    # long time as they have to be built before being installed. And the
+    # arrifacts of the build occupies a lot of space blotting the docker image.
+    # Thus instead a system instllation is made.
+    sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
+    sudo apt-get install -y python-matplotlib python-numpy python-scipy
+    rm -f requirements.txt*
+    cd $CURRENT_DIR
+}
+
+# Install Haskell Dependencies
+install_haskell_dependencies(){
+    if ! is_x68_64_trusty; then
+      MESSAGE="Installing stack for haskell "; message
+      # Just in case curl isn't installed
+      sudo apt-get install -y curl
+      cd /tmp
+      rm -rf stack*
+      wget $(curl -s  https://api.github.com/repos/commercialhaskell/stack/releases/latest | awk '/browser_download_url/&&/i386-linux.tar.gz/' | head -n 1 | cut -d '"' -f 4)
+      tar xfz stack*i386-linux.tar.gz
+      rm stack*i386-linux.tar.gz
+      mv stack* stack
+      chmod 755 stack
+      sudo mv stack /usr/bin/stack
+      rm -f stack*
+      cd $CURRENT_DIR
+    else
+      MESSAGE="Installing haskell dependencies in user space...." ; message
+      # Install stack.
+      add_stack_repository
+      sudo apt-get update && sudo apt-get $QUIET --no-upgrade --assume-yes install stack
+    fi
+
+    # Notes
+    # 1. Stack setup must me run in user space:
+    #    "stack setup" looks for proper ghc version in the system according to
+    #    the information provided by stack.yaml. If it is not installed, it
+    #    attempts to install proper ghc version on user space (~/.stack/...).
+    #    Because of that, it must not be run as root.
+    # 2. Difference b/n .cabal and stack.yaml:
+    #    The .cabal file contains package metadata, in this case
+    #    "opencog-atomspace.cabal" contains information of the opencog-atomspace
+    #    package (autor, license, dependencies, etc.). The stack.yaml file
+    #    contains configuration options for the stack building tool, we use it
+    #    to set the proper "long term support" snapshot that we are using,
+    #    which determines the proper ghc version to use, etc. In this case, it
+    #    doesn't make sense to require the .cabal file, because we are not
+    #    using that information to build the hscolour package, but it looks
+    #    like stack always looks for a .cabal file when building, even though,
+    #    in this case, it doesn't use it.
+    if [ "$EUID" -ne 0 ] ; then
+        cd /tmp
+        wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/stack.yaml
+        wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/opencog-atomspace.cabal
+        stack setup
+
+        # hscolour is necessary for haddock documentation.
+        stack build hscolour --copy-bins
+        rm stack.yaml opencog-atomspace.cabal
+        cd $CURRENT_DIR
+    else
+        echo "Please run without sudo. Stack need to be run in non-root user space."
+    fi
+}
+
+# The following sets the source & build directory for a project
+set_source_and_build_dir() {
+    if [ "$(git rev-parse --is-inside-work-tree)" == true ] ; then
+        SOURCE_DIR=$(git rev-parse --show-toplevel)
+        MESSAGE="Source Directory is set to $SOURCE_DIR" ; message
+        if [ -d $SOURCE_DIR/build ]; then
+            BUILD_DIR=$SOURCE_DIR/build
+            MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
+        else
+            mkdir $SOURCE_DIR/build
+            BUILD_DIR=$SOURCE_DIR/build
+            MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
+        fi
+    else
+        MESSAGE="Exiting $SELF_NAME as git worktree is not detected run inside \
+    a git worktree" ; message
+        exit 1
+    fi
+}
+
+# Build function for opencog, atomspace, moses & cogutils repos
+build_source() {
+    set_source_and_build_dir
+    if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+        rm $BUILD_DIR/CMakeCache.txt
+        MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
+    fi
+    MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
+    #stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+    cmake -B$BUILD_DIR -H$SOURCE_DIR
+    MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS" ; message
+    make -C $BUILD_DIR -j$MAKE_JOBS
+    MESSAGE="Finished building source" ; message
+}
+
+# Build examples function for opencog, atomspace, moses & cogutils repos
+build_examples() {
+    set_source_and_build_dir
+    if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+        rm $BUILD_DIR/CMakeCache.txt
+        MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
+    fi
+    MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
+    #stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+    cmake -B$BUILD_DIR -H$SOURCE_DIR
+    MESSAGE="make -C $BUILD_DIR  -j$MAKE_JOBS examples" ; message
+    make -C $BUILD_DIR -j$MAKE_JOBS examples
+    MESSAGE="Finished building examples" ; message
+}
+
+# Run tests function for opencog, atomspace, moses & cogutils repos
+test_source() {
+    #check if gearman service is running, start it if not
+    if (( $(ps -ef | grep -v grep | grep gearman-job-server | wc -l) > 0 ))
+    then
+        MESSAGE="gearman-job-server is running!!!";message
+    else
+    sudo /etc/init.d/gearman-job-server start
+    fi
+    set_source_and_build_dir
+    if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+        rm $BUILD_DIR/CMakeCache.txt
+        MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
+    fi
+    MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
+    #stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+    cmake -B$BUILD_DIR -H$SOURCE_DIR
+    MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS test" ; message
+    make -C $BUILD_DIR -j$MAKE_JOBS test
+    MESSAGE="Finished building & running tests" ; message
+}
+
+# Install build job artifacts
+install_build() {
+    set_source_and_build_dir
+    MESSAGE="Starting installation" ; message
+    cd $BUILD_DIR
+    sudo make install 1> /dev/null
+    sudo ldconfig
+    cd $CURRENT_DIR
+    MESSAGE="Finished installation" ; message
+}
+
+# Install AtomSpace
+install_atomspace(){
+    MESSAGE="Installing atomspace...." ; message
+    cd /tmp/
+    # cleaning up remnants from previous install failures, if any.
+    rm -rf master.tar.gz* atomspace-master
+    wget https://github.com/opencog/atomspace/archive/master.tar.gz
+    tar -xvf master.tar.gz
+    cd atomspace-master/
+    mkdir build
+    cd build/
+    cmake ..
+    make -j$(nproc)
+    sudo make install
+    sudo ldconfig
+    cd /tmp/
+    rm -rf master.tar.gz atomspace-master/
+    cd $CURRENT_DIR
+}
+
+# Install MOSES
+install_moses(){
+    MESSAGE="Installing MOSES...." ; message
+    cd /tmp/
+    # cleaning up remnants from previous install failures, if any.
+    rm -rf master.tar.gz*  moses-master
+    wget https://github.com/opencog/moses/archive/master.tar.gz
+    tar -xvf master.tar.gz
+    cd moses-master/
+    mkdir build
+    cd build
+    cmake ..
+    make -j$(nproc)
+    sudo make install
+    sudo ldconfig
+    cd /tmp/
+    rm -rf master.tar.gz moses-master/
+    cd $CURRENT_DIR
+}
+
+# Install Link-Grammar
+install_link_grammar(){
+    MESSAGE="Installing Link-Grammar...." ; message
+    cd /tmp/
+    # cleaning up remnants from previous install failures, if any.
+    rm -rf link-grammar-5.*/
+    wget -r --no-parent -nH --cut-dirs=2 http://www.abisource.com/downloads/link-grammar/current/
+    tar -zxf current/link-grammar-5*.tar.gz
+    rm -r current
+    cd link-grammar-5.*/
+    mkdir build
+    cd build
+    ../configure
+    make -j$(nproc)
+    sudo make install
+    sudo ldconfig
+    cd /tmp/
+    rm -rf link-grammar-5.*/
+    cd $CURRENT_DIR
+}
+
+# Installs cpprest that is needed by pattern-miner
+# https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Linux
+install_cpprest(){
+    MESSAGE="Installing cpprest...." ; message
+    cd /tmp/
+    # cleaning up remnants from previous install failures, if any.
+    rm -rf master.tar.gz*  cpprestsdk-master
+    wget https://github.com/Microsoft/cpprestsdk/archive/master.tar.gz
+    tar -xvf master.tar.gz
+    cd cpprestsdk-master/Release
+    mkdir build.release
+    cd build.release
+    CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release
+    make -j$(nproc)
+    sudo make install
+    sudo ldconfig
+    cd /tmp/
+    rm -rf master.tar.gz*  cpprestsdk-master
+    cd $CURRENT_DIR
+}
+
+# Install system dependencies
+install_dependencies() {
+    MESSAGE="Installing OpenCog build dependencies...." ; message
+    if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH; then
+     # commented out the message b/c it is displayed on ctrl + c
+     # MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
+      exit 1
+    fi
+    install_cpprest
+    # test for and fix Ubuntu 14.04 libiberty-dev includefile bug
+    source /etc/lsb-release
+    if [ "$DISTRIB_CODENAME" == "trusty" ] ; then
+      sudo sed -i s:"ansidecl.h":\<libiberty/ansidecl.h\>:g /usr/include/bfd.h || true
+    fi
+}
+
+update_opencog_source() {
+    if sudo apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_FETCH ; then
+      echo -n
+    else
+      MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
+    exit 1
+    fi
+    OPENCOG_SOURCE_DIR=$LIVE_SOURCE_BRANCH
+    mkdir -p $OPENCOG_SOURCE_DIR || true
+    if [ ! "$(ls -A $OPENCOG_SOURCE_DIR/.git)" ]; then
+      MESSAGE="Fetching OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
+      git clone https://github.com/opencog/opencog $OPENCOG_SOURCE_DIR
+    else
+      if [ $UPDATE_OPENCOG ] ; then
+        MESSAGE="Updating OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
+        cd $OPENCOG_SOURCE_DIR
+        git pull
+        cd -
+      fi
+    fi
+}
+
+build_opencog() {
+    mkdir -p -v $LIVE_BUILD_DIR || true
+    cd $LIVE_BUILD_DIR
+    MESSAGE="cmake $LIVE_SOURCE_BRANCH" ; message
+    cmake $LIVE_SOURCE_BRANCH
+    MESSAGE="make -j$MAKE_JOBS" ; message
+    make -j$MAKE_JOBS
+
+    if [ $TEST_OPENCOG ] ; then
+      make test
+    fi
+
+    case $PACKAGE_TYPE in
+      min)    MESSAGE="Installing OpenCog..." ; message
+         make install; exit 0;;
+      demo)    MESSAGE="Installing OpenCog..." ; message
+          make install; exit 0;;
+      dev)    exit 0;;
+    esac
+
+}
+
 
 # TODO: change octool usage to 'octool project command' format. Where projects
 # are opencog, atomspace, cogutils... & commands are setup(for workspace),
@@ -164,420 +520,25 @@ if [ $# -eq 0 ] ; then NO_ARGS=true ; fi
 
 while getopts "abdeipcrstlmhvj:" flag ; do
     case $flag in
-      r)	ADD_REPOSITORIES=true ;;
-      d)	INSTALL_DEPENDENCIES=true ;; #base development packages
-      p)	INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
-      c)	INSTALL_COGUTIL=true ;;
-      a)	INSTALL_ATOMSPACE=true ;;
-      l)	INSTALL_LINK_GRAMMAR=true ;;
-      m)	INSTALL_MOSES=true ;;
-      b)	BUILD_SOURCE=true ;;
-      e)	BUILD_EXAMPLES=true ;;
-      t)	TEST_SOURCE=true ;;
-      v)	unset QUIET ;;
-      j)	MAKE_JOBS="$OPTARG" ;;
-      s)    HASKELL_STACK_SETUP=true;;
-      i)    INSTALL_BUILD=true ;;
-      h)	usage ;;
-      \?)	usage ;;
+      r) ADD_REPOSITORIES=true ;;
+      d) INSTALL_DEPENDENCIES=true ;; #base development packages
+      p) INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
+      c) INSTALL_COGUTIL=true ;;
+      a) INSTALL_ATOMSPACE=true ;;
+      l) INSTALL_LINK_GRAMMAR=true ;;
+      m) INSTALL_MOSES=true ;;
+      b) BUILD_SOURCE=true ;;
+      e) BUILD_EXAMPLES=true ;;
+      t) TEST_SOURCE=true ;;
+      v) unset QUIET ;;
+      j) MAKE_JOBS="$OPTARG" ;;
+      s) HASKELL_STACK_SETUP=true;;
+      i) INSTALL_BUILD=true ;;
+      h) usage ;;
+      \?) usage ;;
       *)  UNKNOWN_FLAGS=true ;;
     esac
 done
-
-shift $((OPTIND-1))
-
-message() {
-echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
-}
-
-debug() {
-MESSAGE="Dropping to debugging chroot prompt..." ; message
-chroot $LIVE_SQUASH_UNION /bin/bash -l
-}
-
-exit_trap() {
-if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
-  MESSAGE="Exiting $SELF_NAME normally..." ; message
-  cleanup_squash
-  cleanup_iso
-fi
-}
-
-quit_trap() {
-if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
-  MESSAGE="Exiting $SELF_NAME by request..." ; message
-  cleanup_squash
-  cleanup_iso
-fi
-}
-
-error_trap() {
-if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
-  MESSAGE="Error trapped while running $SELF_NAME." ; message
-
-  MESSAGE="Cleanup will run after debug." ; message
-  debug
-  cleanup_squash
-  cleanup_iso
-fi
-}
-
-trap error_trap ERR
-trap exit_trap  EXIT
-trap quit_trap  INT HUP QUIT TERM
-
-is_x68_64_trusty() {
-OSREL=$(sed -n 's/DISTRIB_CODENAME=\(.*\)/\1/p' /etc/lsb-release);
-ARCH=$(uname -m);
-if [ "$OSREL" == "trusty" -a "$ARCH" == "x86_64" ]; then
-  return 0
-else
-  return 1
-fi
-}
-
-add_stack_repository() {
-wget -q -O- https://s3.amazonaws.com/download.fpcomplete.com/ubuntu/fpco.key | sudo apt-key add -
-echo 'deb http://download.fpcomplete.com/ubuntu/trusty stable main' | sudo tee /etc/apt/sources.list.d/fpco.list
-}
-
-add_repositories() {
-MESSAGE="Adding software repositories..." ; message
-for REPO in $REPOSITORIES ; do
-  sudo apt-add-repository -y $REPO
-done
-
-# Ros repository for opencog/opencog repo
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-key 0xB01FA116
-
-sudo apt-get $QUIET --assume-yes update
-}
-
-install_admin() {
-MESSAGE="Installing sysadmin tools...." ; message
-if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_ADMIN ; then
-  MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
-  exit 1
-fi
-}
-
-# Install cogutils
-install_cogutil(){
-MESSAGE="Installing cogutils...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz* cogutils-master
-wget https://github.com/opencog/cogutils/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd cogutils-master/
-mkdir build
-cd build/
-cmake ..
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz cogutils-master/
-cd $CURRENT_DIR
-}
-
-# Install Python Packages
-install_opencog_python_packages(){
-MESSAGE="Installing python packages...." ; message
-cd /tmp
-# cleaning up remnants from previous install failures, if any.
-rm -f requirements.txt*
-wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
-# scipy, numpy & matplotlib if installed using python-pip will take a long time
-# as they have to be built before being installed. And the arrifacts of the
-# build occupies a lot of space blotting the docker image. Thus instead a
-# system instllation is made.
-sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
-sudo apt-get install -y python-matplotlib python-numpy python-scipy
-rm -f requirements.txt*
-cd $CURRENT_DIR
-}
-
-# Install Haskell Dependencies
-install_haskell_dependencies(){
-if ! is_x68_64_trusty; then
-  MESSAGE="Installing stack for haskell "; message
-  # Just in case curl isn't installed
-  sudo apt-get install -y curl
-  cd /tmp
-  rm -rf stack*
-  wget $(curl -s  https://api.github.com/repos/commercialhaskell/stack/releases/latest | awk '/browser_download_url/&&/i386-linux.tar.gz/' | head -n 1 | cut -d '"' -f 4)
-  tar xfz stack*i386-linux.tar.gz
-  rm stack*i386-linux.tar.gz
-  mv stack* stack
-  chmod 755 stack
-  sudo mv stack /usr/bin/stack
-  rm -f stack*
-  cd $CURRENT_DIR
-else
-  MESSAGE="Installing haskell dependencies in user space...." ; message
-  # Install stack.
-  add_stack_repository
-  sudo apt-get update && sudo apt-get $QUIET --no-upgrade --assume-yes install stack
-fi
-
-# Notes
-# 1. Stack setup must me run in user space:
-#    "stack setup" looks for proper ghc version in the system according to the
-#    information provided by stack.yaml. If it is not installed, it attempts to
-#    install proper ghc version on user space (~/.stack/...). Because of that,
-#    it must not be run as root.
-
-# 2. Difference b/n .cabal and stack.yaml:
-#    The .cabal file contains package metadata, in this case
-#    "opencog-atomspace.cabal" contains information of the opencog-atomspace
-#    package (autor, license, dependencies, etc.). The stack.yaml file contains
-#    configuration options for the stack building tool, we use it to set the
-#    proper "long term support" snapshot that we are using, which determines the
-#    proper ghc version to use, etc. In this case, it doesn't make sense to
-#    require the .cabal file, because we are not using that information to build
-#    the hscolour package, but it looks like stack always looks for a .cabal
-#    file when building, even though, in this case, it doesn't use it.
-if [ "$EUID" -ne 0 ] ; then
-    cd /tmp
-    wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/stack.yaml
-    wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/opencog-atomspace.cabal
-    stack setup
-
-    # hscolour is necessary for haddock documentation.
-    stack build hscolour --copy-bins
-    rm stack.yaml opencog-atomspace.cabal
-    cd $CURRENT_DIR
-else
-    echo "Please run without sudo. Stack need to be run in non-root user space."
-fi
-}
-
-# The following sets the source & build directory for a project
-set_source_and_build_dir() {
-if [ "$(git rev-parse --is-inside-work-tree)" == true ] ; then
-    SOURCE_DIR=$(git rev-parse --show-toplevel)
-    MESSAGE="Source Directory is set to $SOURCE_DIR" ; message
-    if [ -d $SOURCE_DIR/build ]; then
-        BUILD_DIR=$SOURCE_DIR/build
-        MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
-    else
-        mkdir $SOURCE_DIR/build
-        BUILD_DIR=$SOURCE_DIR/build
-        MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
-    fi
-else
-    MESSAGE="Exiting $SELF_NAME as git worktree is not detected run inside \
-a git worktree" ; message
-    exit 1
-fi
-}
-
-# Build function for opencog, atomspace, moses & cogutils repos
-build_source() {
-set_source_and_build_dir
-if [ -a $BUILD_DIR/CMakeCache.txt ]; then
-    rm $BUILD_DIR/CMakeCache.txt
-    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
-fi
-MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
-#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
-cmake -B$BUILD_DIR -H$SOURCE_DIR
-MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS" ; message
-make -C $BUILD_DIR -j$MAKE_JOBS
-MESSAGE="Finished building source" ; message
-}
-
-# Build examples function for opencog, atomspace, moses & cogutils repos
-build_examples() {
-set_source_and_build_dir
-if [ -a $BUILD_DIR/CMakeCache.txt ]; then
-    rm $BUILD_DIR/CMakeCache.txt
-    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
-fi
-MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
-#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
-cmake -B$BUILD_DIR -H$SOURCE_DIR
-MESSAGE="make -C $BUILD_DIR  -j$MAKE_JOBS examples" ; message
-make -C $BUILD_DIR -j$MAKE_JOBS examples
-MESSAGE="Finished building examples" ; message
-}
-
-# Run tests function for opencog, atomspace, moses & cogutils repos
-test_source() {
-#check if gearman service is running, start it if not
-if (( $(ps -ef | grep -v grep | grep gearman-job-server | wc -l) > 0 ))
-then
-    MESSAGE="gearman-job-server is running!!!";message
-else
-sudo /etc/init.d/gearman-job-server start
-fi
-set_source_and_build_dir
-if [ -a $BUILD_DIR/CMakeCache.txt ]; then
-    rm $BUILD_DIR/CMakeCache.txt
-    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
-fi
-MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
-#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
-cmake -B$BUILD_DIR -H$SOURCE_DIR
-MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS test" ; message
-make -C $BUILD_DIR -j$MAKE_JOBS test
-MESSAGE="Finished building & running tests" ; message
-}
-
-# Install build job artifacts
-install_build() {
-set_source_and_build_dir
-MESSAGE="Starting installation" ; message
-cd $BUILD_DIR
-sudo make install 1> /dev/null
-sudo ldconfig
-cd $CURRENT_DIR
-MESSAGE="Finished installation" ; message
-}
-
-# Install AtomSpace
-install_atomspace(){
-MESSAGE="Installing atomspace...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz* atomspace-master
-wget https://github.com/opencog/atomspace/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd atomspace-master/
-mkdir build
-cd build/
-cmake ..
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz atomspace-master/
-cd $CURRENT_DIR
-}
-
-# Install MOSES
-install_moses(){
-MESSAGE="Installing MOSES...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz*  moses-master
-wget https://github.com/opencog/moses/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd moses-master/
-mkdir build
-cd build
-cmake ..
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz moses-master/
-cd $CURRENT_DIR
-}
-
-# Install Link-Grammar
-install_link_grammar(){
-MESSAGE="Installing Link-Grammar...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf link-grammar-5.*/
-wget -r --no-parent -nH --cut-dirs=2 http://www.abisource.com/downloads/link-grammar/current/
-tar -zxf current/link-grammar-5*.tar.gz
-rm -r current
-cd link-grammar-5.*/
-mkdir build
-cd build
-../configure
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf link-grammar-5.*/
-cd $CURRENT_DIR
-}
-
-# Installs cpprest that is needed by pattern-miner
-# https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Linux
-install_cpprest(){
-MESSAGE="Installing cpprest...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz*  cpprestsdk-master
-wget https://github.com/Microsoft/cpprestsdk/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd cpprestsdk-master/Release
-mkdir build.release
-cd build.release
-CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz*  cpprestsdk-master
-cd $CURRENT_DIR
-}
-
-# Install system dependencies
-install_dependencies() {
-MESSAGE="Installing OpenCog build dependencies...." ; message
-if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH; then
- # commented out the message b/c it is displayed on ctrl + c
- # MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
-  exit 1
-fi
-install_cpprest
-# test for and fix Ubuntu 14.04 libiberty-dev includefile bug
-source /etc/lsb-release
-if [ "$DISTRIB_CODENAME" == "trusty" ] ; then
-  sudo sed -i s:"ansidecl.h":\<libiberty/ansidecl.h\>:g /usr/include/bfd.h || true
-fi
-}
-
-update_opencog_source() {
-if sudo apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_FETCH ; then
-  echo -n
-else
-  MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
-exit 1
-fi
-OPENCOG_SOURCE_DIR=$LIVE_SOURCE_BRANCH
-mkdir -p $OPENCOG_SOURCE_DIR || true
-if [ ! "$(ls -A $OPENCOG_SOURCE_DIR/.git)" ]; then
-  MESSAGE="Fetching OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
-  git clone https://github.com/opencog/opencog $OPENCOG_SOURCE_DIR
-else
-  if [ $UPDATE_OPENCOG ] ; then
-    MESSAGE="Updating OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
-    cd $OPENCOG_SOURCE_DIR
-    git pull
-    cd -
-  fi
-fi
-}
-
-build_opencog() {
-mkdir -p -v $LIVE_BUILD_DIR || true
-cd $LIVE_BUILD_DIR
-MESSAGE="cmake $LIVE_SOURCE_BRANCH" ; message
-cmake $LIVE_SOURCE_BRANCH
-MESSAGE="make -j$MAKE_JOBS" ; message
-make -j$MAKE_JOBS
-
-if [ $TEST_OPENCOG ] ; then
-  make test
-fi
-
-case $PACKAGE_TYPE in
-  min)	MESSAGE="Installing OpenCog..." ; message
- 	make install; exit 0;;
-  demo)	MESSAGE="Installing OpenCog..." ; message
-  	make install; exit 0;;
-  dev)	exit 0;;
-esac
-
-}
 
 # Main Program (MAIN main):
 # This is mainly for configuring workspaces depending on the type

--- a/octool
+++ b/octool
@@ -1,1 +1,599 @@
-ocpkg
+#!/bin/bash
+#
+## @file		octool
+## @copyright		OpenCog Foundation 2016
+## @section DESCRIPTION	A script to download, build, test, install and
+##          configure OpenCog projects
+
+# trap errors
+set -e
+
+SELF_NAME=$(basename $0)
+PROCESSORS=$(grep "^processor" /proc/cpuinfo | wc -l)
+MAKE_JOBS=$(($PROCESSORS+0))
+
+VERBOSE="-v"
+QUIET="-qq"
+
+REPOSITORIES="
+		ppa:opencog-dev/ppa \
+		"
+
+PACKAGES_FETCH="
+        python-pip \
+		git \
+			"
+
+PACKAGES_BUILD="
+		build-essential \
+		cmake \
+		cxxtest \
+		rlwrap \
+		guile-2.0-dev \
+		libiberty-dev \
+		libicu-dev \
+		libbz2-dev \
+		cython \
+		python-dev \
+		python-zmq \
+		python-simplejson \
+		libboost-date-time-dev \
+		libboost-filesystem-dev \
+		libboost-math-dev \
+		libboost-program-options-dev \
+		libboost-regex-dev \
+		libboost-serialization-dev \
+		libboost-thread-dev \
+		libboost-system-dev \
+		libboost-random-dev \
+		libjson-spirit-dev \
+		libzmq3-dev \
+		libtbb-dev \
+		binutils-dev \
+		unixodbc-dev \
+		uuid-dev \
+		libprotoc-dev \
+		protobuf-compiler \
+		libsdl-gfx1.2-dev \
+		libssl-dev \
+		tcl-dev \
+		tcsh \
+		libfreetype6-dev \
+		libatlas-base-dev \
+		gfortran \
+		gearman \
+		libgearman-dev \
+		ros-indigo-octomap \
+		"
+
+PACKAGES_RUNTIME="
+		unixodbc \
+		odbc-postgresql \
+		postgresql-client \
+		"
+
+PACKAGES_DOC="
+		ubuntu-docs \
+		libglib2.0-doc \
+		libpango1.0-doc \
+		libgtk-3-doc \
+		texlive-latex-base-doc \
+		python-doc \
+		devhelp-common \
+		texlive-doc-base \
+		doxygen \
+ 		dot2tex \
+		"
+
+PACKAGES_EXDEV="
+		autoconf automake autotools-dev \
+		blt \
+		comerr-dev \
+		dpkg-dev \
+		emacsen-common \
+		fakeroot \
+		gettext \
+		gdb \
+		g++-4.6 \
+		gcc-4.6 \
+		krb5-multidev \
+		libc6-dev \
+		libdpkg-perl \
+		libdpkg-perl \
+		libgcrypt11-dev \
+		libglade2-0 \
+		libgnutls-dev \
+		libgpg-error-dev \
+		libgssrpc4 \
+		libidn11-dev \
+		libalgorithm-diff-perl \
+		libalgorithm-diff-xs-perl \
+		libalgorithm-merge-perl \
+		libkadm5clnt-mit8 \
+		libkadm5srv-mit8 \
+		libkrb5-dev \
+		libldap2-dev \
+		libltdl-dev \
+		libstdc++6-4.6-dev \
+		libtasn1-3-dev \
+		libtimedate-perl \
+		libtool \
+		libunistring0 \
+		libxss1 \
+		make \
+		manpages-dev \
+		m4 \
+		patch \
+		python-glade2 \
+		python-tk \
+		tcl8.5 \
+		tk8.5 \
+		ttf-lyx \
+		zlib1g-dev \
+		python-bzrlib \
+		linux-headers-generic \
+		"
+
+
+usage() {
+    echo "Usage: $SELF_NAME OPTION"
+    echo " -r Add software repositories"
+    echo " -d Install base/system build dependencies"
+    echo " -p Install python build dependencies"
+    echo " -s Install haskell build dependencies in user space. Don't use sudo"
+    echo " -i Install build-job artifacts"
+    echo " -c Install Cogutils"
+    echo " -a Install Atomspace"
+    echo " -l Install Link Grammar"
+    echo " -m Install MOSES"
+    echo " -b Build source code in git worktree found @ $PWD"
+    echo " -e Build examples in git worktree found @ $PWD"
+    echo " -t Run tests of source code in git worktree found @ $PWD"
+    echo " -j [jobs] override number of auto-detected make jobs"
+    echo " -v Verbose output for 'apt-get' commands"
+    echo " -h This help message"
+}
+
+
+# TODO: change octool usage to 'octool project command' format. Where projects
+# are opencog, atomspace, cogutils... & commands are setup(for workspace),
+# package(for docker,deb, rpm). Each will have various options/sub-commands.
+#if [ $1 ] && [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
+
+if [ $# -eq 0 ] ; then NO_ARGS=true ; fi
+
+while getopts "abdeipcrstlmhvj:" flag ; do
+    case $flag in
+      r)	ADD_REPOSITORIES=true ;;
+      d)	INSTALL_DEPENDENCIES=true ;; #base development packages
+      p)	INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
+      c)	INSTALL_COGUTIL=true ;;
+      a)	INSTALL_ATOMSPACE=true ;;
+      l)	INSTALL_LINK_GRAMMAR=true ;;
+      m)	INSTALL_MOSES=true ;;
+      b)	BUILD_SOURCE=true ;;
+      e)	BUILD_EXAMPLES=true ;;
+      t)	TEST_SOURCE=true ;;
+      v)	unset QUIET ;;
+      j)	MAKE_JOBS="$OPTARG" ;;
+      s)    HASKELL_STACK_SETUP=true;;
+      i)    INSTALL_BUILD=true ;;
+      h)	usage ;;
+      \?)	usage ;;
+      *)  UNKNOWN_FLAGS=true ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+message() {
+echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+}
+
+debug() {
+MESSAGE="Dropping to debugging chroot prompt..." ; message
+chroot $LIVE_SQUASH_UNION /bin/bash -l
+}
+
+exit_trap() {
+if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
+  MESSAGE="Exiting $SELF_NAME normally..." ; message
+  cleanup_squash
+  cleanup_iso
+fi
+}
+
+quit_trap() {
+if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
+  MESSAGE="Exiting $SELF_NAME by request..." ; message
+  cleanup_squash
+  cleanup_iso
+fi
+}
+
+error_trap() {
+if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
+  MESSAGE="Error trapped while running $SELF_NAME." ; message
+
+  MESSAGE="Cleanup will run after debug." ; message
+  debug
+  cleanup_squash
+  cleanup_iso
+fi
+}
+
+trap error_trap ERR
+trap exit_trap  EXIT
+trap quit_trap  INT HUP QUIT TERM
+
+is_x68_64_trusty() {
+OSREL=$(sed -n 's/DISTRIB_CODENAME=\(.*\)/\1/p' /etc/lsb-release);
+ARCH=$(uname -m);
+if [ "$OSREL" == "trusty" -a "$ARCH" == "x86_64" ]; then
+  return 0
+else
+  return 1
+fi
+}
+
+add_stack_repository() {
+wget -q -O- https://s3.amazonaws.com/download.fpcomplete.com/ubuntu/fpco.key | sudo apt-key add -
+echo 'deb http://download.fpcomplete.com/ubuntu/trusty stable main' | sudo tee /etc/apt/sources.list.d/fpco.list
+}
+
+add_repositories() {
+MESSAGE="Adding software repositories..." ; message
+for REPO in $REPOSITORIES ; do
+  sudo apt-add-repository -y $REPO
+done
+
+# Ros repository for opencog/opencog repo
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-key 0xB01FA116
+
+sudo apt-get $QUIET --assume-yes update
+}
+
+install_admin() {
+MESSAGE="Installing sysadmin tools...." ; message
+if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_ADMIN ; then
+  MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
+  exit 1
+fi
+}
+
+# Install cogutils
+install_cogutil(){
+MESSAGE="Installing cogutils...." ; message
+cd /tmp/
+# cleaning up remnants from previous install failures, if any.
+rm -rf master.tar.gz* cogutils-master
+wget https://github.com/opencog/cogutils/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd cogutils-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+cd /tmp/
+rm -rf master.tar.gz cogutils-master/
+cd $CURRENT_DIR
+}
+
+# Install Python Packages
+install_opencog_python_packages(){
+MESSAGE="Installing python packages...." ; message
+cd /tmp
+# cleaning up remnants from previous install failures, if any.
+rm -f requirements.txt*
+wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/requirements.txt
+# scipy, numpy & matplotlib if installed using python-pip will take a long time
+# as they have to be built before being installed. And the arrifacts of the
+# build occupies a lot of space blotting the docker image. Thus instead a
+# system instllation is made.
+sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
+sudo apt-get install -y python-matplotlib python-numpy python-scipy
+rm -f requirements.txt*
+cd $CURRENT_DIR
+}
+
+# Install Haskell Dependencies
+install_haskell_dependencies(){
+if ! is_x68_64_trusty; then
+  MESSAGE="Installing stack for haskell "; message
+  # Just in case curl isn't installed
+  sudo apt-get install -y curl
+  cd /tmp
+  rm -rf stack*
+  wget $(curl -s  https://api.github.com/repos/commercialhaskell/stack/releases/latest | awk '/browser_download_url/&&/i386-linux.tar.gz/' | head -n 1 | cut -d '"' -f 4)
+  tar xfz stack*i386-linux.tar.gz
+  rm stack*i386-linux.tar.gz
+  mv stack* stack
+  chmod 755 stack
+  sudo mv stack /usr/bin/stack
+  rm -f stack*
+  cd $CURRENT_DIR
+else
+  MESSAGE="Installing haskell dependencies in user space...." ; message
+  # Install stack.
+  add_stack_repository
+  sudo apt-get update && sudo apt-get $QUIET --no-upgrade --assume-yes install stack
+fi
+
+# Notes
+# 1. Stack setup must me run in user space:
+#    "stack setup" looks for proper ghc version in the system according to the
+#    information provided by stack.yaml. If it is not installed, it attempts to
+#    install proper ghc version on user space (~/.stack/...). Because of that,
+#    it must not be run as root.
+
+# 2. Difference b/n .cabal and stack.yaml:
+#    The .cabal file contains package metadata, in this case
+#    "opencog-atomspace.cabal" contains information of the opencog-atomspace
+#    package (autor, license, dependencies, etc.). The stack.yaml file contains
+#    configuration options for the stack building tool, we use it to set the
+#    proper "long term support" snapshot that we are using, which determines the
+#    proper ghc version to use, etc. In this case, it doesn't make sense to
+#    require the .cabal file, because we are not using that information to build
+#    the hscolour package, but it looks like stack always looks for a .cabal
+#    file when building, even though, in this case, it doesn't use it.
+if [ "$EUID" -ne 0 ] ; then
+    cd /tmp
+    wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/stack.yaml
+    wget https://raw.githubusercontent.com/opencog/atomspace/master/opencog/haskell/opencog-atomspace.cabal
+    stack setup
+
+    # hscolour is necessary for haddock documentation.
+    stack build hscolour --copy-bins
+    rm stack.yaml opencog-atomspace.cabal
+    cd $CURRENT_DIR
+else
+    echo "Please run without sudo. Stack need to be run in non-root user space."
+fi
+}
+
+# The following sets the source & build directory for a project
+set_source_and_build_dir() {
+if [ "$(git rev-parse --is-inside-work-tree)" == true ] ; then
+    SOURCE_DIR=$(git rev-parse --show-toplevel)
+    MESSAGE="Source Directory is set to $SOURCE_DIR" ; message
+    if [ -d $SOURCE_DIR/build ]; then
+        BUILD_DIR=$SOURCE_DIR/build
+        MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
+    else
+        mkdir $SOURCE_DIR/build
+        BUILD_DIR=$SOURCE_DIR/build
+        MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
+    fi
+else
+    MESSAGE="Exiting $SELF_NAME as git worktree is not detected run inside \
+a git worktree" ; message
+    exit 1
+fi
+}
+
+# Build function for opencog, atomspace, moses & cogutils repos
+build_source() {
+set_source_and_build_dir
+if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+    rm $BUILD_DIR/CMakeCache.txt
+    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
+fi
+MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
+#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+cmake -B$BUILD_DIR -H$SOURCE_DIR
+MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS" ; message
+make -C $BUILD_DIR -j$MAKE_JOBS
+MESSAGE="Finished building source" ; message
+}
+
+# Build examples function for opencog, atomspace, moses & cogutils repos
+build_examples() {
+set_source_and_build_dir
+if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+    rm $BUILD_DIR/CMakeCache.txt
+    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
+fi
+MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
+#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+cmake -B$BUILD_DIR -H$SOURCE_DIR
+MESSAGE="make -C $BUILD_DIR  -j$MAKE_JOBS examples" ; message
+make -C $BUILD_DIR -j$MAKE_JOBS examples
+MESSAGE="Finished building examples" ; message
+}
+
+# Run tests function for opencog, atomspace, moses & cogutils repos
+test_source() {
+#check if gearman service is running, start it if not
+if (( $(ps -ef | grep -v grep | grep gearman-job-server | wc -l) > 0 ))
+then
+    MESSAGE="gearman-job-server is running!!!";message
+else
+sudo /etc/init.d/gearman-job-server start
+fi
+set_source_and_build_dir
+if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+    rm $BUILD_DIR/CMakeCache.txt
+    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
+fi
+MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
+#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+cmake -B$BUILD_DIR -H$SOURCE_DIR
+MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS test" ; message
+make -C $BUILD_DIR -j$MAKE_JOBS test
+MESSAGE="Finished building & running tests" ; message
+}
+
+# Install build job artifacts
+install_build() {
+set_source_and_build_dir
+MESSAGE="Starting installation" ; message
+cd $BUILD_DIR
+sudo make install 1> /dev/null
+sudo ldconfig
+cd $CURRENT_DIR
+MESSAGE="Finished installation" ; message
+}
+
+# Install AtomSpace
+install_atomspace(){
+MESSAGE="Installing atomspace...." ; message
+cd /tmp/
+# cleaning up remnants from previous install failures, if any.
+rm -rf master.tar.gz* atomspace-master
+wget https://github.com/opencog/atomspace/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd atomspace-master/
+mkdir build
+cd build/
+cmake ..
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+cd /tmp/
+rm -rf master.tar.gz atomspace-master/
+cd $CURRENT_DIR
+}
+
+# Install MOSES
+install_moses(){
+MESSAGE="Installing MOSES...." ; message
+cd /tmp/
+# cleaning up remnants from previous install failures, if any.
+rm -rf master.tar.gz*  moses-master
+wget https://github.com/opencog/moses/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd moses-master/
+mkdir build
+cd build
+cmake ..
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+cd /tmp/
+rm -rf master.tar.gz moses-master/
+cd $CURRENT_DIR
+}
+
+# Install Link-Grammar
+install_link_grammar(){
+MESSAGE="Installing Link-Grammar...." ; message
+cd /tmp/
+# cleaning up remnants from previous install failures, if any.
+rm -rf link-grammar-5.*/
+wget -r --no-parent -nH --cut-dirs=2 http://www.abisource.com/downloads/link-grammar/current/
+tar -zxf current/link-grammar-5*.tar.gz
+rm -r current
+cd link-grammar-5.*/
+mkdir build
+cd build
+../configure
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+cd /tmp/
+rm -rf link-grammar-5.*/
+cd $CURRENT_DIR
+}
+
+# Installs cpprest that is needed by pattern-miner
+# https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Linux
+install_cpprest(){
+MESSAGE="Installing cpprest...." ; message
+cd /tmp/
+# cleaning up remnants from previous install failures, if any.
+rm -rf master.tar.gz*  cpprestsdk-master
+wget https://github.com/Microsoft/cpprestsdk/archive/master.tar.gz
+tar -xvf master.tar.gz
+cd cpprestsdk-master/Release
+mkdir build.release
+cd build.release
+CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+cd /tmp/
+rm -rf master.tar.gz*  cpprestsdk-master
+cd $CURRENT_DIR
+}
+
+# Install system dependencies
+install_dependencies() {
+MESSAGE="Installing OpenCog build dependencies...." ; message
+if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH; then
+ # commented out the message b/c it is displayed on ctrl + c
+ # MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
+  exit 1
+fi
+install_cpprest
+# test for and fix Ubuntu 14.04 libiberty-dev includefile bug
+source /etc/lsb-release
+if [ "$DISTRIB_CODENAME" == "trusty" ] ; then
+  sudo sed -i s:"ansidecl.h":\<libiberty/ansidecl.h\>:g /usr/include/bfd.h || true
+fi
+}
+
+update_opencog_source() {
+if sudo apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_FETCH ; then
+  echo -n
+else
+  MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
+exit 1
+fi
+OPENCOG_SOURCE_DIR=$LIVE_SOURCE_BRANCH
+mkdir -p $OPENCOG_SOURCE_DIR || true
+if [ ! "$(ls -A $OPENCOG_SOURCE_DIR/.git)" ]; then
+  MESSAGE="Fetching OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
+  git clone https://github.com/opencog/opencog $OPENCOG_SOURCE_DIR
+else
+  if [ $UPDATE_OPENCOG ] ; then
+    MESSAGE="Updating OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
+    cd $OPENCOG_SOURCE_DIR
+    git pull
+    cd -
+  fi
+fi
+}
+
+build_opencog() {
+mkdir -p -v $LIVE_BUILD_DIR || true
+cd $LIVE_BUILD_DIR
+MESSAGE="cmake $LIVE_SOURCE_BRANCH" ; message
+cmake $LIVE_SOURCE_BRANCH
+MESSAGE="make -j$MAKE_JOBS" ; message
+make -j$MAKE_JOBS
+
+if [ $TEST_OPENCOG ] ; then
+  make test
+fi
+
+case $PACKAGE_TYPE in
+  min)	MESSAGE="Installing OpenCog..." ; message
+ 	make install; exit 0;;
+  demo)	MESSAGE="Installing OpenCog..." ; message
+  	make install; exit 0;;
+  dev)	exit 0;;
+esac
+
+}
+
+# Main Program (MAIN main):
+# This is mainly for configuring workspaces depending on the type
+# of project being worked on. The order here matters.
+if [ $ADD_REPOSITORIES ] ; then add_repositories ; fi
+if [ $INSTALL_DEPENDENCIES ] ; then install_dependencies ; fi
+if [ $HASKELL_STACK_SETUP ] ; then install_haskell_dependencies ; fi
+if [ $INSTALL_OPENCOG_PYTHON_PACKAGES ] ; then install_opencog_python_packages ; fi
+if [ $INSTALL_COGUTIL ] ; then install_cogutil ; fi
+if [ $INSTALL_ATOMSPACE ] ; then install_atomspace ; fi
+if [ $INSTALL_LINK_GRAMMAR ] ; then install_link_grammar ; fi
+if [ $INSTALL_MOSES ] ; then install_moses ; fi
+if [ $BUILD_SOURCE ] ; then build_source ; fi
+if [ $BUILD_EXAMPLES ] ; then build_examples ; fi
+if [ $TEST_SOURCE ] ; then test_source ; fi
+if [ $INSTALL_BUILD ] ; then install_build ; fi
+if [ $UNKNOWN_FLAGS ] ; then usage ; fi
+if [ $NO_ARGS ] ; then usage ; fi
+exit 0


### PR DESCRIPTION
* The aim is to make octool the default devops tool, that is independent of platform and aware of opencog repos.
* It is compatiable with ocpkg's octool