### PR TITLE
Update ocpkg

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -620,8 +620,8 @@ if ! is_x68_64; then
   cd /tmp
   rm -rf stack*
   wget $( curl -s  https://api.github.com/repos/commercialhaskell/stack/releases/latest | awk '/browser_download_url/&&/stack-[0-9\.]*-linux-i386.tar.gz/' | head -n 1 | cut -d '"' -f 4)
-  tar xfz stack*i386-linux.tar.gz
-  rm stack*i386-linux.tar.gz
+  tar xfz stack*linux-i386.tar.gz
+  rm stack*i386-linux-i386.tar.gz
   mv stack* stack
   chmod 755 stack
   sudo mv stack /usr/bin/stack


### PR DESCRIPTION
An update to the link for stack installation on i386 systems (pulled here: https://github.com/opencog/ocpkg/pull/64/files) broke the tar and rm commands that followed.  Fixed that by changing "i386-linux" to "linux-i386" in those two lines