### PR TITLE
remove hack that disabled building of pretty printing of stack traces in cogutils.

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -858,11 +858,6 @@ if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_BUILD $PACK
   exit 1
 fi
 install_cpprest
-# test for and fix Ubuntu 14.04 libiberty-dev includefile bug
-source /etc/lsb-release
-if [ "$DISTRIB_CODENAME" == "trusty" ] ; then
-  sudo sed -i s:"ansidecl.h":\<libiberty/ansidecl.h\>:g /usr/include/bfd.h || true
-fi
 }
 
 update_opencog_source() {

--- a/octool-wip
+++ b/octool-wip
@@ -405,11 +405,6 @@ install_dependencies() {
       exit 1
     fi
     install_cpprest
-    # test for and fix Ubuntu 14.04 libiberty-dev includefile bug
-    source /etc/lsb-release
-    if [ "$DISTRIB_CODENAME" == "trusty" ] ; then
-      sudo sed -i s:"ansidecl.h":\<libiberty/ansidecl.h\>:g /usr/include/bfd.h || true
-    fi
 }
 
 # Updates a git source directory if it is one of the opencog cmake projects.


### PR DESCRIPTION
It seems the hack is not needed as per  https://github.com/opencog/cogutils/issues/1 and the hack wasn't correctly formatted.

See and https://github.com/opencog/opencog/issues/696 for why it was added.