### PR TITLE
Fixed wrong filename in ocpkg script that breaks installation

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -621,7 +621,7 @@ if ! is_x68_64; then
   rm -rf stack*
   wget $( curl -s  https://api.github.com/repos/commercialhaskell/stack/releases/latest | awk '/browser_download_url/&&/stack-[0-9\.]*-linux-i386.tar.gz/' | head -n 1 | cut -d '"' -f 4)
   tar xfz stack*linux-i386.tar.gz
-  rm stack*i386-linux-i386.tar.gz
+  rm stack*linux-i386.tar.gz
   mv stack* stack
   chmod 755 stack
   sudo mv stack /usr/bin/stack


### PR DESCRIPTION
Vagrant installation failed, because of wrong filename in ocpkg, 'stack*i386-linux-i386.tar.gz' should be 'stack*linux-i386.tar.gz'.