### PR TITLE
Don't install libjson-spirit-dev

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -143,7 +143,6 @@ PACKAGES_BUILD="
 		libboost-thread-dev \
 		libboost-system-dev \
 		libboost-random-dev \
-		libjson-spirit-dev \
 		libzmq3-dev \
 		libtbb-dev \
 		binutils-dev \


### PR DESCRIPTION
Because it is vendored into opencog/opencog repo

Resolves #70 