### PR TITLE
Move guile gdb extenstion file to gdb auto-load path

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -939,6 +939,7 @@ cd build
 ../configure
 make -j$(nproc)
 sudo make install
+sudo mv  /usr/local/lib/libguile-2.2.so.1.3.0-gdb.scm /usr/share/gdb/auto-load/
 sudo ldconfig
 cd /tmp/
 rm -rf guile-${GUILEVERSION}*


### PR DESCRIPTION
Implement https://github.com/opencog/opencog/issues/3041#issuecomment-379994569 thus avoiding user confusion.