### PR TITLE
Remove libjson-spirit-dev because not found on debian testing

### DIFF
--- a/debian/install-debian-dependencies.sh
+++ b/debian/install-debian-dependencies.sh
@@ -40,7 +40,6 @@ PACKAGES_BUILD="
 		libboost-serialization-dev \
 		libboost-thread-dev \
 		libboost-system-dev \
-		libjson-spirit-dev \
 		libzmq3-dev \
 		libtbb-dev \
 		binutils-dev \


### PR DESCRIPTION
Reference: https://github.com/opencog/ocpkg/issues/70