### PR TITLE
faster java-> oracle and minor mods

### DIFF
--- a/octool_rpi.sh
+++ b/octool_rpi.sh
@@ -52,7 +52,9 @@ INSTALL_PACKAGES="
 	libatomic-ops-dev \
 	libunistring-dev \
 	libffi-dev \
-	libreadline-dev "
+	libreadline-dev \
+	liboctomap-dev 
+	"
 
 INSTALL_RELEX_DEPS="
 	swig \
@@ -62,6 +64,7 @@ INSTALL_RELEX_DEPS="
 	libatomic-ops-dev \
 	libgmp-dev \
 	libffi-dev \
+	oracle-java8-jdk \
 	ant \
 	libcommons-logging-java \
 	libgetopt-java "
@@ -177,6 +180,9 @@ do_cc_for_rpi () {
 	tar -xf $CC_TC_BOOST_1_62_LIBS.tar.gz -C $CC_TC_LIBS_PATH_2/opt
 	cp -Prf $VERBOSE $CC_TC_BOOST_1_62_LIBS/include/boost $CC_TC_LIBS_PATH_2/usr/include
 	cp -Prf $VERBOSE $CC_TC_BOOST_1_62_LIBS/lib/arm-linux-gnueabihf/* $CC_TC_LIBS_PATH_2/usr/lib
+	# boost 1.62 needs stdc++ 6.0.22
+	cd $CC_TC_LIBS_PATH_2/../lib
+	ln -sf $CC_TC_LIBS_PATH_2/opt/libstdc++.so.6.0.22 libstdc++.so.6
 	export DEB_PKG_NAME="opencog-dev_1.0-2_armhf"
 	export DPKG__V="1.0-2"
     else
@@ -184,6 +190,9 @@ do_cc_for_rpi () {
 	tar -xf $CC_TC_BOOST_1_55_LIBS.tar.gz -C $CC_TC_LIBS_PATH_2/opt
 	cp -Prf $VERBOSE $CC_TC_BOOST_1_55_LIBS/include/boost $CC_TC_LIBS_PATH_2/usr/include
 	cp -Prf $VERBOSE $CC_TC_BOOST_1_55_LIBS/lib/arm-linux-gnueabihf/* $CC_TC_LIBS_PATH_2/usr/lib
+	# boost 1.55 needs stdc++ 6.0.20
+	cd $CC_TC_LIBS_PATH_2/../lib
+	ln -sf $CC_TC_LIBS_PATH_2/opt/libstdc++.so.6.0.20 libstdc++.so.6
 	export DEB_PKG_NAME="opencog-dev_1.0-1_armhf"
     fi
 
@@ -417,10 +426,12 @@ if [ $INSTALL_DEPS ] ; then
 		if [ "$DISTRO_RELEASE" == "$DISTRO_STRETCH" ] ; then
 			sudo apt-get install -y $APT_ARGS libboost1.62-dev
 		else
+			#install boost 1.55
+			sudo apt-get install -y $APT_ARGS libboost1.55-all-dev
 			#install boost 1.60
-			wget http://144.76.153.5/opencog/libboost-1.60-all-dev-1_armhf.deb
-			sudo dpkg -i libboost-1.60-all-dev-1_armhf.deb
-			rm libboost-1.60-all-dev-1_armhf.deb
+			#wget http://144.76.153.5/opencog/libboost-1.55-all-dev-1_armhf.deb
+			#sudo dpkg -i libboost-1.55-all-dev-1_armhf.deb
+			#rm libboost-1.55-all-dev-1_armhf.deb
 		fi
 	#	install_bdwgc # install bdwgc from source
 	#	install_guile # install guile  from source
@@ -430,7 +441,9 @@ if [ $INSTALL_DEPS ] ; then
 		install_tbb   # install TBB
 		
 		sudo apt-get -y install $APT_ARGS $INSTALL_RELEX_DEPS
-    		export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-armhf
+		sudo update-alternatives --auto java 
+		sudo update-alternatives --auto javac
+    		export JAVA_HOME=/usr/lib/jvm/jdk-8-oracle-arm32-vfp-hflt
     		export LC_ALL=en_US.UTF8
 		install_lg   # install link-grammar
 		install_relex # install relex


### PR DESCRIPTION
relex was too slow on a rpi3 and benchmarking with [scimark2](https://math.nist.gov/scimark2/about.html) gave surprising results. 
ghost took like 5 seconds to parse a single rule with openjdk but with
oracle it's like 155ms average

java version "1.7.0_171"                                                
OpenJDK Runtime Environment (IcedTea 2.6.13) (7u171-2.6.13-1~deb8u1+rpi1)
OpenJDK Zero VM (build 24.171-b02, interpreted mode)                    

SciMark 2.0a                                      
                                                 
Composite Score: 4.067622544974023                
FFT (1024): 2.4731180786248257                    
SOR (100x100):   7.982150425831123                
Monte Carlo : 0.7656633578690619                  
Sparse matmult (N=1000, nz=5000): 3.95672324808641 
LU (100x100): 5.160457614458691                    
 
===========================================================

java version "1.7.0_60"
Java(TM) SE Runtime Environment (build 1.7.0_60-b19)
Java HotSpot(TM) Client VM (build 24.60-b09, mixed mode)

SciMark 2.0a

Composite Score: 83.67902099261036
FFT (1024): 76.39455956757855
SOR (100x100):   163.46750852899444
Monte Carlo : 24.901248854299705
Sparse matmult (N=1000, nz=5000): 59.34081518252189
LU (100x100): 94.29097282965719