### PR TITLE
Solve the "Unmappable character for encoding ASCII" in relex installa…

### DIFF
--- a/octool_rpi.sh
+++ b/octool_rpi.sh
@@ -361,6 +361,7 @@ install_relex () {
     sudo chmod $VERBOSE  0644 /usr/local/share/java/jwnl.jar
     
     #installing relex
+    export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
     wget https://github.com/Dagiopia/relex/archive/$RELEX_V.tar.gz
     tar $VERBOSE -xf $RELEX_V.tar.gz 
     cd relex-$RELEX_V


### PR DESCRIPTION
I figured the error "Unmappable character for encoding ASCII" is  appearing in any new raspberry-pi while compiling relex.  So it would save one a time if the line "export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" is included in the script. 