### PR TITLE
Add python unit test runner: nosetests to run Python unit tests in CI

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -136,6 +136,7 @@ PACKAGES_BUILD="
 		python3-zmq \
                 python3-pip
 		python3-simplejson \
+		python3-nose \
 		libboost-date-time-dev \
 		libboost-filesystem-dev \
 		libboost-math-dev \


### PR DESCRIPTION
Install `nosetests` - Python unittesting tool which is required to run Python unit tests during CI run.

@AmeBel, I believe to have it in CI we need to build and publish new `opencog-deps` docker image using [this docker script](https://github.com/opencog/docker/blob/master/opencog/base/Dockerfile). How can I do it? Do I need permissions?