### PR TITLE
Adding all dependencies which were part of the atomspace and opencog

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -857,6 +857,7 @@ MESSAGE="Finished installation" ; message
 # Install AtomSpace
 install_atomspace(){
 install_opencog_github_repo atomspace
+install_opencog_github_repo ure
 }
 
 # Install CogServer
@@ -867,6 +868,12 @@ install_opencog_github_repo cogserver
 # Install OpenCog
 install_opencog(){
 install_opencog_github_repo opencog
+install_opencog_github_repo miner
+install_opencog_github_repo learn
+install_opencog_github_repo attentionbank
+install_opencog_github_repo spacetime
+install_opencog_github_repo pattern-index
+install_opencog_github_repo visualization
 }
 
 # Install MOSES


### PR DESCRIPTION
Adding all components which were moved out of `atomspace` and `opencog` repos under https://github.com/opencog/opencog/issues/3391. I have added them into `atomspace` and `opencog` installation steps respectively to not introduce new parameters which will require changes to documentation and [docker image](https://github.com/opencog/docker/blob/master/opencog/tools/cli/Dockerfile) Components are listed in https://github.com/opencog/opencog/issues/3391#issuecomment-528232685