### PR TITLE
Install learn after cogserver and opencog as learn depends on cogserver

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -845,13 +845,13 @@ install_opencog_github_repo cogserver
 install_opencog(){
 install_opencog_github_repo pln
 install_opencog_github_repo miner
-install_opencog_github_repo learn
 install_opencog_github_repo cogserver
 install_opencog_github_repo attention
 install_opencog_github_repo spacetime
 install_opencog_github_repo pattern-index
 install_opencog_github_repo visualization
 install_opencog_github_repo opencog
+install_opencog_github_repo learn
 }
 
 # Install MOSES


### PR DESCRIPTION
One liner. It breaks `learn` installation in opencog-dev image.